### PR TITLE
spdk: add vfio-user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
             ./rpc.py bdev_malloc_create -b Malloc0 64 512 && \
             ./rpc.py bdev_malloc_create -b Malloc1 64 512 && \
             ./rpc.py nvmf_create_transport -t TCP -u 8192 -m 4 -c 0  && \
+            ./rpc.py nvmf_create_transport -t VFIOUSER && \
             ./rpc.py nvmf_create_subsystem nqn.2016-06.io.spdk:cnode1 -a -s SPDK00000000000001 -d SPDK_Controller1  && \
             ./rpc.py nvmf_subsystem_add_listener nqn.2016-06.io.spdk:cnode1 -t tcp -a  `hostname -i` -f ipv4 -s 4444  && \
             ./rpc.py nvmf_subsystem_allow_any_host nqn.2016-06.io.spdk:cnode1 --disable && \

--- a/spdk/Dockerfile
+++ b/spdk/Dockerfile
@@ -16,9 +16,9 @@ RUN git clone https://github.com/spdk/spdk --branch ${TAG} --depth 1 && \
     cd spdk && git submodule update --init --depth 1 && scripts/pkgdep.sh --rdma
 
 # hadolint ignore=DL3003
-RUN cd spdk && ./rpmbuild/rpm.sh --target-arch=${ARCH} --without-uring --with-crypto \
+RUN cd spdk && DEPS="no" LDFLAGS=" " ./rpmbuild/rpm.sh --target-arch=${ARCH} --without-uring --with-crypto \
     --without-fio --with-raid5f --with-vhost --without-pmdk --without-rbd \
-    --with-rdma --with-shared --with-iscsi-initiator --without-vtune
+    --with-rdma --without-shared --with-iscsi-initiator --without-vtune --with-vfio-user
 
 FROM docker.io/library/fedora:37
 


### PR DESCRIPTION
For some reason when adding --with-vfio-user
RPM build is not working any more
So adding ugly hack `LDFLAGS=" "`
and `--without-shared`

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
