### PR TITLE
temp workaround for listener

### DIFF
--- a/scripts/poc.sh
+++ b/scripts/poc.sh
@@ -56,6 +56,13 @@ tests_poc() {
     "${grpc_cli[@]}" ls opi-spdk-server:50051 opi_api.storage.v1.VirtioScsiControllerService -l
     "${grpc_cli[@]}" ls opi-spdk-server:50051 opi_api.storage.v1.VirtioScsiLunService -l
 
+    # test nvme
+    "${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 NVMeNamespaceCreate "{'namespace' : {'id' : {'value' : 'namespace1'}, 'subsystem_id' : { 'value' : 'nqn.2016-06.io.spdk:cnode1' }, 'volume_id' : { 'value' : 'Malloc1' }, 'host_nsid' : '1' } }"
+    "${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 NVMeNamespaceGet "{'namespace_id' : {'value' : 'namespace1'} }"
+    docker run --rm --network=host --privileged -v /dev/hugepages:/dev/hugepages ghcr.io/opiproject/opi-spdk:main spdk_nvme_identify -r 'traddr:127.0.0.1 trtype:TCP adrfam:IPv4 trsvcid:4444'
+    docker run --rm --network=host --privileged -v /dev/hugepages:/dev/hugepages ghcr.io/opiproject/opi-spdk:main spdk_nvme_perf     -r 'traddr:127.0.0.1 trtype:TCP adrfam:IPv4 trsvcid:4444' -c 0x1 -q 1 -o 4096 -w randread -t 10
+    "${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 NVMeNamespaceDelete "{'namespace_id' : {'value' : 'namespace1'} }"
+
     # this is last line
     docker-compose ps -a
 }

--- a/server/frontend.go
+++ b/server/frontend.go
@@ -205,7 +205,9 @@ func (s *server) NVMeNamespaceCreate(ctx context.Context, in *pb.NVMeNamespaceCr
 	if !ok {
 		err := fmt.Errorf("unable to find subsystem %s", in.Namespace.SubsystemId.Value)
 		log.Printf("error: %v", err)
-		return nil, err
+		// TODO: temp workaround
+		subsys = &pb.NVMeSubsystem{Nqn: in.Namespace.SubsystemId.Value}
+		// return nil, err
 	}
 
 	params := NvmfSubsystemAddNsParams{
@@ -245,7 +247,9 @@ func (s *server) NVMeNamespaceDelete(ctx context.Context, in *pb.NVMeNamespaceDe
 	if !ok {
 		err := fmt.Errorf("unable to find subsystem %s", namespace.SubsystemId.Value)
 		log.Printf("error: %v", err)
-		return nil, err
+		// TODO: temp workaround
+		subsys = &pb.NVMeSubsystem{Nqn: namespace.SubsystemId.Value}
+		// return nil, err
 	}
 
 	params := NvmfSubsystemRemoveNsParams{
@@ -331,7 +335,9 @@ func (s *server) NVMeNamespaceGet(ctx context.Context, in *pb.NVMeNamespaceGetRe
 	if !ok {
 		err := fmt.Errorf("unable to find subsystem %s", namespace.SubsystemId.Value)
 		log.Printf("error: %v", err)
-		return nil, err
+		// TODO: temp workaround
+		subsys = &pb.NVMeSubsystem{Nqn: namespace.SubsystemId.Value}
+		// return nil, err
 	}
 
 	var result []NvmfGetSubsystemsResult


### PR DESCRIPTION
in testing we use nqn.2016-06.io.spdk:cnode1
with pre-defined transport and listener
so need to keep this code for now

will remove once we add transport and listener calls

tracking this here #31 

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
