### PR TITLE
docker: reduce images size

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,8 +1,7 @@
-# syntax=docker/dockerfile:1
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Dell Inc, or its subsidiaries.
 
-# Alpine is chosen for its small footprint
-# compared to Ubuntu
-FROM docker.io/library/golang:1.19.5-alpine
+FROM docker.io/library/golang:1.19.5-alpine as builder
 
 WORKDIR /app
 
@@ -15,5 +14,8 @@ RUN go mod download
 COPY *.go ./
 RUN go build -v -o /opi-storage-client && CGO_ENABLED=0 go test -v ./...
 
+# second stage to reduce image size
+FROM alpine:3.17
+COPY --from=builder /opi-storage-client /
 EXPOSE 50051
-CMD [ "/opi-storage-client" ]
+CMD [ "/opi-storage-client"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,8 @@ services:
       spdk:
         condition: service_healthy
     command: /opi-spdk-bridge -port=50051
+    healthcheck:
+      test: grpcurl -plaintext localhost:50051 list || exit 1
 
   opi-spdk-client:
     build:
@@ -66,7 +68,8 @@ services:
     networks:
       - opi
     depends_on:
-      - opi-spdk-server
+      opi-spdk-server:
+        condition: service_healthy
     command: /opi-storage-client -addr=opi-spdk-server:50051
 
 networks:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,8 +1,7 @@
-# syntax=docker/dockerfile:1
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Dell Inc, or its subsidiaries.
 
-# Alpine is chosen for its small footprint
-# compared to Ubuntu
-FROM docker.io/library/golang:1.19.5-alpine
+FROM docker.io/library/golang:1.19.5-alpine as builder
 
 WORKDIR /app
 
@@ -15,5 +14,10 @@ RUN go mod download
 COPY *.go ./
 RUN go build -v -o /opi-spdk-bridge && CGO_ENABLED=0 go test -v ./...
 
+# second stage to reduce image size
+FROM alpine:3.17
+COPY --from=builder /opi-spdk-bridge /
+COPY --from=docker.io/fullstorydev/grpcurl:v1.8.7-alpine /bin/grpcurl /usr/local/bin/
 EXPOSE 50051
-CMD [ "/opi-spdk-bridge" ]
+CMD [ "/opi-spdk-bridge", "-port=50051" ]
+HEALTHCHECK CMD grpcurl -plaintext localhost:50051 list || exit 1


### PR DESCRIPTION
By introducing multi-stage build
And switching to alpine
And using grpcurl from docker

x10 size reduction !

```
$ docker images | grep opi
opi-storage-server                      main           44996bc55718   About a minute ago   50.7MB
ghcr.io/opiproject/opi-storage-server   main           ae1f6b66da01   18 hours ago         618MB

```

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
