### PR TITLE
Fixed #140 accel_crypto_key_create missing Key2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
             echo 1024 > /proc/sys/vm/nr_hugepages && \
             grep "" /sys/kernel/mm/hugepages/hugepages-*/nr_hugepages && \
             dd if=/dev/zero of=/tmp/aio_bdev_file bs=512 count=64 && \
-            /usr/local/bin/spdk_tgt -m 0x1 -s 512 --no-pci -S /var/tmp 2>&1 & \
+            /usr/local/bin/spdk_tgt -m 0x1 -s 512 --no-pci -S /var/tmp |& tee /tmp/spdk.log & \
             for i in `seq 1 10`; do ./rpc.py spdk_get_version && break || sleep 1; done  && \
             ./rpc.py bdev_malloc_create -b Malloc0 64 512 && \
             ./rpc.py bdev_malloc_create -b Malloc1 64 512 && \

--- a/pkg/server/middleend.go
+++ b/pkg/server/middleend.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	pc "github.com/opiproject/opi-api/common/v1/gen/go"
 	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
@@ -25,6 +26,7 @@ func (s *Server) CreateEncryptedVolume(ctx context.Context, in *pb.CreateEncrypt
 		Cipher: "AES_XTS",
 		Name:   "super_key",
 		Key:    string(in.EncryptedVolume.Key),
+		Key2:   strings.Repeat("a", len(in.EncryptedVolume.Key)),
 	}
 	// TODO: use in.EncryptedVolume.Cipher.String()
 	// TODO: don't use hard-coded key name
@@ -107,8 +109,9 @@ func (s *Server) UpdateEncryptedVolume(ctx context.Context, in *pb.UpdateEncrypt
 	// first create a key
 	params2 := AccelCryptoKeyCreateParams{
 		Cipher: "AES_XTS",
-		Name:   "super_key",
+		Name:   "super_key2",
 		Key:    string(in.EncryptedVolume.Key),
+		Key2:   strings.Repeat("b", len(in.EncryptedVolume.Key)),
 	}
 	// TODO: use in.EncryptedVolume.Cipher.String()
 	// TODO: don't use hard-coded key name


### PR DESCRIPTION
`Key2` is marked as optional but SPDK mandates it in the code still...
https://spdk.io/doc/jsonrpc.html#rpc_accel_crypto_key_create
```
spdk_1             | [2023-02-09 15:52:03.456606] accel_sw.c: 707:sw_accel_create_aes_xts: *ERROR*: key size 16 is not equal to key2 size 0 or is 0
```

Signed-off-by: Boris Glimcher <36732377+glimchb@users.noreply.github.com>