### PR TITLE
Add extension capabilities.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2022 Dell Inc, or its subsidiaries.
+# Copyright (C) 2023 Intel Corporation
 
 FROM docker.io/library/golang:1.20.1-alpine as builder
 
@@ -13,7 +14,7 @@ RUN go mod download
 # build an app
 COPY cmd/ cmd/
 COPY pkg/ pkg/
-RUN go build -v -o /opi-spdk-bridge ./cmd/... && CGO_ENABLED=0 go test -v ./...
+RUN go build -v -o /opi-spdk-bridge ./cmd && CGO_ENABLED=0 go test -v ./...
 
 # second stage to reduce image size
 FROM alpine:3.17

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ This project welcomes contributions and suggestions.  We are happy to have the C
 
 See [CONTRIBUTING](https://github.com/opiproject/opi/blob/main/CONTRIBUTING.md) and [GitHub Basic Process](https://github.com/opiproject/opi/blob/main/doc-github-rules.md) for more details.
 
+## Extensions
+
+If your xPU uses a standard SPDK JSON RPC call set, this bridge can be extended to exercise dedicated JSON rpc calls and by this provide means for xPU-specific behavior customization.
+To extend this bridge, add your source code as explained in [`extension.go`](./pkg/server/extension/extension.go), and build your own binary.
+
 ## Docs
 
 * [JSON RPC Proxy](https://spdk.io/doc/jsonrpc_proxy.html)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,42 +3,9 @@
 package main
 
 import (
-	"flag"
-	"fmt"
-	"log"
-	"net"
-
-	"github.com/opiproject/opi-spdk-bridge/pkg/server"
-
-	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/reflection"
-)
-
-var (
-	port = flag.Int("port", 50051, "The Server port")
+	"github.com/opiproject/opi-spdk-bridge/cmd/server"
 )
 
 func main() {
-	flag.Parse()
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
-	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
-	}
-	s := grpc.NewServer()
-
-	pb.RegisterFrontendNvmeServiceServer(s, &server.Server{})
-	pb.RegisterNVMfRemoteControllerServiceServer(s, &server.Server{})
-	pb.RegisterFrontendVirtioBlkServiceServer(s, &server.Server{})
-	pb.RegisterFrontendVirtioScsiServiceServer(s, &server.Server{})
-	pb.RegisterNullDebugServiceServer(s, &server.Server{})
-	pb.RegisterAioControllerServiceServer(s, &server.Server{})
-	pb.RegisterMiddleendServiceServer(s, &server.Server{})
-
-	reflection.Register(s)
-
-	log.Printf("Server listening at %v", lis.Addr())
-	if err := s.Serve(lis); err != nil {
-		log.Fatalf("failed to serve: %v", err)
-	}
+	server.Run()
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -1,0 +1,52 @@
+// Package server contains the code which can be used to start opi-spdk-bridge
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022 Dell Inc, or its subsidiaries.
+// Copyright (C) 2023 Intel Corporation
+package server
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/opiproject/opi-spdk-bridge/pkg/server"
+	"github.com/opiproject/opi-spdk-bridge/pkg/server/extension"
+
+	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+)
+
+var (
+	port = flag.Int("port", 50051, "The Server port")
+)
+
+// Run is used to start opi-spdk-bridge instance
+func Run() {
+	flag.Parse()
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	s := grpc.NewServer()
+	baseSpdkServer := &server.Server{}
+	spdkServer, err := extension.Extend(baseSpdkServer)
+	if err != nil {
+		log.Fatalf("failed to apply extension: %v", err)
+	}
+	pb.RegisterFrontendNvmeServiceServer(s, spdkServer)
+	pb.RegisterNVMfRemoteControllerServiceServer(s, spdkServer)
+	pb.RegisterFrontendVirtioBlkServiceServer(s, spdkServer)
+	pb.RegisterFrontendVirtioScsiServiceServer(s, spdkServer)
+	pb.RegisterNullDebugServiceServer(s, spdkServer)
+	pb.RegisterAioControllerServiceServer(s, spdkServer)
+	pb.RegisterMiddleendServiceServer(s, spdkServer)
+
+	reflection.Register(s)
+
+	log.Printf("Server listening at %v", lis.Addr())
+	if err := s.Serve(lis); err != nil {
+		log.Fatalf("failed to serve: %v", err)
+	}
+}

--- a/pkg/server/extension/extension.go
+++ b/pkg/server/extension/extension.go
@@ -1,0 +1,113 @@
+// Package extension provides capabilities to use extension to change base SPDK
+// server behavior
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Intel Corporation
+package extension
+
+import (
+	"github.com/opiproject/opi-spdk-bridge/pkg/server"
+)
+
+/*
+This package provides the ability to create an extension for xPU by exposing
+default SPDK JSON RPC interface, but requiring adjustments only for some of
+the calls.
+
+There are several ways how to add an extension:
+- By forking this repo and providing the extension code in the fork's
+pkg/server/extension package.
+- By importing opi-spdk-bridge package into a dedicated xPU repo and using this
+extension package to register your addition.
+
+To provide an extension, a user needs to create a dedicated struct which is
+leveraging Go embedding capabilities for server.OpiServer interface e.g.
+```
+
+	type myXpuServer struct  {
+		server.OpiServer
+		muField1 string
+		muField2 string
+	}
+
+```
+
+After that customizations should be provided for required calls e.g.
+```
+
+	func (s *myXpuServer) CreateVirtioBlk(
+		ctx context.Context,
+		in *pb.CreateVirtioBlkRequest) (*pb.VirtioBlk, error) {
+
+		// do something specific for this xPU
+	}
+
+```
+
+Here, the rest of the calls rely on the default opi-spdk-bridge implementation,
+but CreateVirtioBlk will have its own behavior.
+
+Then a function to embed the base SPDK bridge into myXpuServer should be
+created.
+```
+
+	func myExtension(baseSpdkServer server.OpiServer) (server.OpiServer, error) {
+		return myXpuServer {
+			baseSpdkServer, // embed the default bridge
+			"my param 1",
+			"my param 2"
+		}, nil
+	}
+
+```
+
+The function above should be passed into RegisterExtension function.
+- If extension code was added into extension package, then init() function can
+be used to register the extension.
+```
+	// somewhere in extension directory
+	func init() {
+		RegisterExtension(myExtension)
+	}
+
+```
+- If opi-spdk-bridge server was imported into a dedicated xPU repository as a
+package, then a separate main should be added with extension registration
+and the bridge needs starting like:
+```
+
+	// myXpuMain.go
+	import github.com/opiproject/opi-spdk-bridge/cmd/server
+	import github.com/opiproject/opi-spdk-bridge/pkg/server/extension
+
+	func main() {
+		extension.RegisterExtension(myExtension)
+		server.Run()
+	}
+
+```
+*/
+
+// Extension type declares function signature which can be used
+// to apply an extension to baseSpdkServer and return the extended server.
+type Extension func(baseSpdkServer server.OpiServer) (server.OpiServer, error)
+
+var extensions []Extension
+
+// RegisterExtension is used to register a new Extension to be applied to the
+// base SPDK server.
+func RegisterExtension(extension Extension) {
+	extensions = append(extensions, extension)
+}
+
+// Extend is used at the bridge start procedure to apply any registered
+// extensions on baseSpdkServer and return the extended server.
+func Extend(baseSpdkServer server.OpiServer) (server.OpiServer, error) {
+	for _, extension := range extensions {
+		s, err := extension(baseSpdkServer)
+		if err != nil {
+			return nil, err
+		}
+		baseSpdkServer = s
+	}
+	return baseSpdkServer, nil
+}

--- a/pkg/server/extension/extension_test.go
+++ b/pkg/server/extension/extension_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Intel Corporation
+package extension
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/opiproject/opi-spdk-bridge/pkg/server"
+)
+
+type stubServer struct {
+	server.OpiServer
+	tag int
+}
+
+func TestExtend(t *testing.T) {
+	extensions = nil
+	stubErr := errors.New("Stub error")
+	baseSpdkServer := &server.Server{}
+	tests := map[string]struct {
+		expectedErr     error
+		extensionFuncs  []Extension
+		checkOutputType func(server.OpiServer, *testing.T)
+	}{
+		"No extensions are applied by default": {
+			checkOutputType: func(s server.OpiServer, t *testing.T) {
+				if s != baseSpdkServer {
+					t.Errorf("Expected unmodified baseSpdkServer, received: %v", s)
+				}
+			},
+		},
+		"Applying extensions failed": {
+			expectedErr: stubErr,
+			extensionFuncs: []Extension{func(baseSpdkServer server.OpiServer) (server.OpiServer, error) {
+				return baseSpdkServer, stubErr
+			}},
+			checkOutputType: func(s server.OpiServer, t *testing.T) {
+				if s != nil {
+					t.Errorf("Expected nil as output, received: %v", s)
+				}
+			},
+		},
+		"Extensions are applied successfully in right order": {
+			extensionFuncs: []Extension{
+				func(baseSpdkServer server.OpiServer) (server.OpiServer, error) {
+					return &stubServer{baseSpdkServer, 1}, nil
+				}, func(baseSpdkServer server.OpiServer) (server.OpiServer, error) {
+					return &stubServer{baseSpdkServer, 2}, nil
+				}},
+			checkOutputType: func(s server.OpiServer, t *testing.T) {
+				server, ok := s.(*stubServer)
+				if !ok {
+					t.Errorf("Couldn't type assert %T to *stubServer", s)
+				}
+				if server.tag != 2 {
+					t.Errorf("Expected tag: %v, received: %v", 2, server.tag)
+				}
+
+				embeddedServer, ok := server.OpiServer.(*stubServer)
+				if !ok {
+					t.Errorf("Couldn't type assert %T to *stubServer", server.OpiServer)
+				}
+				if embeddedServer.tag != 1 {
+					t.Errorf("Expected tag: %v, received: %v", 1, embeddedServer.tag)
+				}
+
+				if embeddedServer.OpiServer != baseSpdkServer {
+					t.Errorf("Expected baseSpdkServer, received: %T", embeddedServer.OpiServer)
+				}
+			},
+		},
+	}
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			for _, ext := range test.extensionFuncs {
+				RegisterExtension(ext)
+			}
+			newServer, err := Extend(baseSpdkServer)
+			extensions = nil
+
+			if err != test.expectedErr {
+				t.Errorf("Expected err: %v, received: %v", test.expectedErr, err)
+			}
+			test.checkOutputType(newServer, t)
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,9 +1,21 @@
 // Package server implements the server
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2022 Dell Inc, or its subsidiaries.
+// Copyright (C) 2023 Intel Corporation
 package server
 
 import _go "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+
+// OpiServer interface represents server which implements storage OPI API
+type OpiServer interface {
+	_go.FrontendNvmeServiceServer
+	_go.NVMfRemoteControllerServiceServer
+	_go.FrontendVirtioBlkServiceServer
+	_go.FrontendVirtioScsiServiceServer
+	_go.NullDebugServiceServer
+	_go.AioControllerServiceServer
+	_go.MiddleendServiceServer
+}
 
 // Server represents the Server object
 type Server struct {


### PR DESCRIPTION
For xPUs which utilize a standard set of SPDK JSON RPC calls with only a limited number of non-standard xPU-specific operations, this patch allows for creating xPU extensions to encapsulate the non-standard operations within device-specific add-ons.

This patch allows to create extensions in two different ways:
* By forking the bridge and adding the code to a dedicated package
* By importing the bridge package into a dedicated xPU repo

The proposed approaches facilitate SPDK and opi-spdk-bridge code reuse for multiple xPUs.