### PR TITLE
Avoid using global variables for NVMe parameters.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2022 Dell Inc, or its subsidiaries.
+// Copyright (C) 2023 Intel Corporation
 package main
 
 import (
@@ -29,9 +30,11 @@ func main() {
 	}
 	s := grpc.NewServer()
 
-	pb.RegisterFrontendNvmeServiceServer(s, &frontend.Server{})
-	pb.RegisterFrontendVirtioBlkServiceServer(s, &frontend.Server{})
-	pb.RegisterFrontendVirtioScsiServiceServer(s, &frontend.Server{})
+	frontendServer := frontend.NewServer()
+
+	pb.RegisterFrontendNvmeServiceServer(s, frontendServer)
+	pb.RegisterFrontendVirtioBlkServiceServer(s, frontendServer)
+	pb.RegisterFrontendVirtioScsiServiceServer(s, frontendServer)
 	pb.RegisterNVMfRemoteControllerServiceServer(s, &backend.Server{})
 	pb.RegisterNullDebugServiceServer(s, &backend.Server{})
 	pb.RegisterAioControllerServiceServer(s, &backend.Server{})

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -2,7 +2,7 @@
 // Copyright (c) 2022 Dell Inc, or its subsidiaries.
 // Copyright (C) 2023 Intel Corporation
 
-// Package frontend implememnts the FrontEnd APIs (host facing) of the storage Server
+// Package frontend implements the FrontEnd APIs (host facing) of the storage Server
 package frontend
 
 import (
@@ -25,11 +25,31 @@ var (
 	errUnexpectedSpdkCallResult = status.Error(codes.FailedPrecondition, "Unexpected SPDK call result.")
 )
 
+// NvmeParameters contains all NVMe related structures
+type NvmeParameters struct {
+	Subsystems  map[string]*pb.NVMeSubsystem
+	Controllers map[string]*pb.NVMeController
+	Namespaces  map[string]*pb.NVMeNamespace
+}
+
 // Server contains frontend related OPI services
 type Server struct {
 	pb.UnimplementedFrontendNvmeServiceServer
 	pb.UnimplementedFrontendVirtioBlkServiceServer
 	pb.UnimplementedFrontendVirtioScsiServiceServer
+
+	Nvme NvmeParameters
+}
+
+// NewServer creates initialized instance of NVMe server
+func NewServer() *Server {
+	return &Server{
+		Nvme: NvmeParameters{
+			Subsystems:  make(map[string]*pb.NVMeSubsystem),
+			Controllers: make(map[string]*pb.NVMeController),
+			Namespaces:  make(map[string]*pb.NVMeNamespace),
+		},
+	}
 }
 
 // CreateVirtioBlk creates a Virtio block device


### PR DESCRIPTION
In this change, NVMe related global variables are moved into frontend Server structure. It is good design practise to avoid global variables in the code. It makes design flexible and testable. NVMe parameters are made exported from package to provide possibility for clients to leverage them in xPU specific code.

In addition, this patch removes dependency on test execution order.