### PR TITLE
Avoid using globals for JSON RPC.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,7 +31,7 @@ func main() {
 	}
 	s := grpc.NewServer()
 
-	jsonRPC := server.NewJSONRPC(spdkSocket)
+	jsonRPC := server.NewUnixSocketJSONRPC(spdkSocket)
 	frontendServer := frontend.NewServerWithJSONRPC(jsonRPC)
 	backendServer := backend.NewServerWithJSONRPC(jsonRPC)
 	middleendServer := middleend.NewServerWithJSONRPC(jsonRPC)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,8 +22,8 @@ import (
 func main() {
 	var port int
 	flag.IntVar(&port, "port", 50051, "The Server port")
-	spdkSocket := *server.RPCSock
 	flag.Parse()
+	spdkSocket := *server.RPCSock
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {

--- a/pkg/backend/aio.go
+++ b/pkg/backend/aio.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2022 Dell Inc, or its subsidiaries.
+// Copyright (C) 2023 Intel Corporation
 
 // Package backend implememnts the BackEnd APIs (network facing) of the storage Server
 package backend
@@ -12,7 +13,6 @@ import (
 	pc "github.com/opiproject/opi-api/common/v1/gen/go"
 	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
 	"github.com/opiproject/opi-spdk-bridge/pkg/models"
-	"github.com/opiproject/opi-spdk-bridge/pkg/server"
 
 	"github.com/ulule/deepcopier"
 	"google.golang.org/grpc/codes"
@@ -29,7 +29,7 @@ func (s *Server) CreateAioController(ctx context.Context, in *pb.CreateAioContro
 		Filename:  in.AioController.Filename,
 	}
 	var result models.BdevAioCreateResult
-	err := server.Call("bdev_aio_create", &params, &result)
+	err := s.RPC.Call("bdev_aio_create", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -51,7 +51,7 @@ func (s *Server) DeleteAioController(ctx context.Context, in *pb.DeleteAioContro
 		Name: in.Name,
 	}
 	var result models.BdevAioDeleteResult
-	err := server.Call("bdev_aio_delete", &params, &result)
+	err := s.RPC.Call("bdev_aio_delete", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -70,7 +70,7 @@ func (s *Server) UpdateAioController(ctx context.Context, in *pb.UpdateAioContro
 		Name: in.AioController.Handle.Value,
 	}
 	var result1 models.BdevAioDeleteResult
-	err1 := server.Call("bdev_aio_delete", &params1, &result1)
+	err1 := s.RPC.Call("bdev_aio_delete", &params1, &result1)
 	if err1 != nil {
 		log.Printf("error: %v", err1)
 		return nil, err1
@@ -85,7 +85,7 @@ func (s *Server) UpdateAioController(ctx context.Context, in *pb.UpdateAioContro
 		Filename:  in.AioController.Filename,
 	}
 	var result2 models.BdevAioCreateResult
-	err2 := server.Call("bdev_aio_create", &params2, &result2)
+	err2 := s.RPC.Call("bdev_aio_create", &params2, &result2)
 	if err2 != nil {
 		log.Printf("error: %v", err2)
 		return nil, err2
@@ -98,7 +98,7 @@ func (s *Server) UpdateAioController(ctx context.Context, in *pb.UpdateAioContro
 func (s *Server) ListAioControllers(ctx context.Context, in *pb.ListAioControllersRequest) (*pb.ListAioControllersResponse, error) {
 	log.Printf("ListAioControllers: Received from client: %v", in)
 	var result []models.BdevGetBdevsResult
-	err := server.Call("bdev_get_bdevs", nil, &result)
+	err := s.RPC.Call("bdev_get_bdevs", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -119,7 +119,7 @@ func (s *Server) GetAioController(ctx context.Context, in *pb.GetAioControllerRe
 		Name: in.Name,
 	}
 	var result []models.BdevGetBdevsResult
-	err := server.Call("bdev_get_bdevs", &params, &result)
+	err := s.RPC.Call("bdev_get_bdevs", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -141,7 +141,7 @@ func (s *Server) AioControllerStats(ctx context.Context, in *pb.AioControllerSta
 	}
 	// See https://mholt.github.io/json-to-go/
 	var result models.BdevGetIostatResult
-	err := server.Call("bdev_get_iostat", &params, &result)
+	err := s.RPC.Call("bdev_get_iostat", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err

--- a/pkg/backend/aio.go
+++ b/pkg/backend/aio.go
@@ -29,7 +29,7 @@ func (s *Server) CreateAioController(ctx context.Context, in *pb.CreateAioContro
 		Filename:  in.AioController.Filename,
 	}
 	var result models.BdevAioCreateResult
-	err := s.RPC.Call("bdev_aio_create", &params, &result)
+	err := s.rpc.Call("bdev_aio_create", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -51,7 +51,7 @@ func (s *Server) DeleteAioController(ctx context.Context, in *pb.DeleteAioContro
 		Name: in.Name,
 	}
 	var result models.BdevAioDeleteResult
-	err := s.RPC.Call("bdev_aio_delete", &params, &result)
+	err := s.rpc.Call("bdev_aio_delete", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -70,7 +70,7 @@ func (s *Server) UpdateAioController(ctx context.Context, in *pb.UpdateAioContro
 		Name: in.AioController.Handle.Value,
 	}
 	var result1 models.BdevAioDeleteResult
-	err1 := s.RPC.Call("bdev_aio_delete", &params1, &result1)
+	err1 := s.rpc.Call("bdev_aio_delete", &params1, &result1)
 	if err1 != nil {
 		log.Printf("error: %v", err1)
 		return nil, err1
@@ -85,7 +85,7 @@ func (s *Server) UpdateAioController(ctx context.Context, in *pb.UpdateAioContro
 		Filename:  in.AioController.Filename,
 	}
 	var result2 models.BdevAioCreateResult
-	err2 := s.RPC.Call("bdev_aio_create", &params2, &result2)
+	err2 := s.rpc.Call("bdev_aio_create", &params2, &result2)
 	if err2 != nil {
 		log.Printf("error: %v", err2)
 		return nil, err2
@@ -98,7 +98,7 @@ func (s *Server) UpdateAioController(ctx context.Context, in *pb.UpdateAioContro
 func (s *Server) ListAioControllers(ctx context.Context, in *pb.ListAioControllersRequest) (*pb.ListAioControllersResponse, error) {
 	log.Printf("ListAioControllers: Received from client: %v", in)
 	var result []models.BdevGetBdevsResult
-	err := s.RPC.Call("bdev_get_bdevs", nil, &result)
+	err := s.rpc.Call("bdev_get_bdevs", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -119,7 +119,7 @@ func (s *Server) GetAioController(ctx context.Context, in *pb.GetAioControllerRe
 		Name: in.Name,
 	}
 	var result []models.BdevGetBdevsResult
-	err := s.RPC.Call("bdev_get_bdevs", &params, &result)
+	err := s.rpc.Call("bdev_get_bdevs", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -141,7 +141,7 @@ func (s *Server) AioControllerStats(ctx context.Context, in *pb.AioControllerSta
 	}
 	// See https://mholt.github.io/json-to-go/
 	var result models.BdevGetIostatResult
-	err := s.RPC.Call("bdev_get_iostat", &params, &result)
+	err := s.rpc.Call("bdev_get_iostat", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -27,7 +27,7 @@ type Server struct {
 	pb.UnimplementedNullDebugServiceServer
 	pb.UnimplementedAioControllerServiceServer
 
-	RPC *server.JSONRPC
+	RPC server.JSONRPC
 }
 
 // NewServer creates initialized instance of BackEnd server
@@ -37,7 +37,7 @@ func NewServer() *Server {
 
 // NewServerWithJSONRPC creates initialized instance of BackEnd server communicating
 // with provided jsonRPC
-func NewServerWithJSONRPC(jsonRPC *server.JSONRPC) *Server {
+func NewServerWithJSONRPC(jsonRPC server.JSONRPC) *Server {
 	return &Server{
 		RPC: jsonRPC,
 	}

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -27,7 +27,7 @@ type Server struct {
 	pb.UnimplementedNullDebugServiceServer
 	pb.UnimplementedAioControllerServiceServer
 
-	RPC server.JSONRPC
+	rpc server.JSONRPC
 }
 
 // NewServer creates initialized instance of BackEnd server
@@ -39,7 +39,7 @@ func NewServer() *Server {
 // with provided jsonRPC
 func NewServerWithJSONRPC(jsonRPC server.JSONRPC) *Server {
 	return &Server{
-		RPC: jsonRPC,
+		rpc: jsonRPC,
 	}
 }
 
@@ -52,7 +52,7 @@ func (s *Server) CreateNullDebug(ctx context.Context, in *pb.CreateNullDebugRequ
 		NumBlocks: 64,
 	}
 	var result models.BdevNullCreateResult
-	err := s.RPC.Call("bdev_null_create", &params, &result)
+	err := s.rpc.Call("bdev_null_create", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -74,7 +74,7 @@ func (s *Server) DeleteNullDebug(ctx context.Context, in *pb.DeleteNullDebugRequ
 		Name: in.Name,
 	}
 	var result models.BdevNullDeleteResult
-	err := s.RPC.Call("bdev_null_delete", &params, &result)
+	err := s.rpc.Call("bdev_null_delete", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -93,7 +93,7 @@ func (s *Server) UpdateNullDebug(ctx context.Context, in *pb.UpdateNullDebugRequ
 		Name: in.NullDebug.Handle.Value,
 	}
 	var result1 models.BdevNullDeleteResult
-	err1 := s.RPC.Call("bdev_null_delete", &params1, &result1)
+	err1 := s.rpc.Call("bdev_null_delete", &params1, &result1)
 	if err1 != nil {
 		log.Printf("error: %v", err1)
 		return nil, err1
@@ -108,7 +108,7 @@ func (s *Server) UpdateNullDebug(ctx context.Context, in *pb.UpdateNullDebugRequ
 		NumBlocks: 64,
 	}
 	var result2 models.BdevNullCreateResult
-	err2 := s.RPC.Call("bdev_null_create", &params2, &result2)
+	err2 := s.rpc.Call("bdev_null_create", &params2, &result2)
 	if err2 != nil {
 		log.Printf("error: %v", err2)
 		return nil, err2
@@ -127,7 +127,7 @@ func (s *Server) UpdateNullDebug(ctx context.Context, in *pb.UpdateNullDebugRequ
 func (s *Server) ListNullDebugs(ctx context.Context, in *pb.ListNullDebugsRequest) (*pb.ListNullDebugsResponse, error) {
 	log.Printf("ListNullDebugs: Received from client: %v", in)
 	var result []models.BdevGetBdevsResult
-	err := s.RPC.Call("bdev_get_bdevs", nil, &result)
+	err := s.rpc.Call("bdev_get_bdevs", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -148,7 +148,7 @@ func (s *Server) GetNullDebug(ctx context.Context, in *pb.GetNullDebugRequest) (
 		Name: in.Name,
 	}
 	var result []models.BdevGetBdevsResult
-	err := s.RPC.Call("bdev_get_bdevs", &params, &result)
+	err := s.rpc.Call("bdev_get_bdevs", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -170,7 +170,7 @@ func (s *Server) NullDebugStats(ctx context.Context, in *pb.NullDebugStatsReques
 	}
 	// See https://mholt.github.io/json-to-go/
 	var result models.BdevGetIostatResult
-	err := s.RPC.Call("bdev_get_iostat", &params, &result)
+	err := s.rpc.Call("bdev_get_iostat", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err

--- a/pkg/backend/nvme.go
+++ b/pkg/backend/nvme.go
@@ -34,7 +34,7 @@ func (s *Server) CreateNVMfRemoteController(ctx context.Context, in *pb.CreateNV
 		Hostnqn: in.NvMfRemoteController.Hostnqn,
 	}
 	var result []models.BdevNvmeAttachControllerResult
-	err := s.RPC.Call("bdev_nvme_attach_controller", &params, &result)
+	err := s.rpc.Call("bdev_nvme_attach_controller", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -59,7 +59,7 @@ func (s *Server) DeleteNVMfRemoteController(ctx context.Context, in *pb.DeleteNV
 		Name: in.Name,
 	}
 	var result models.BdevNvmeDetachControllerResult
-	err := s.RPC.Call("bdev_nvme_detach_controller", &params, &result)
+	err := s.rpc.Call("bdev_nvme_detach_controller", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -78,7 +78,7 @@ func (s *Server) NVMfRemoteControllerReset(ctx context.Context, in *pb.NVMfRemot
 func (s *Server) ListNVMfRemoteControllers(ctx context.Context, in *pb.ListNVMfRemoteControllersRequest) (*pb.ListNVMfRemoteControllersResponse, error) {
 	log.Printf("ListNVMfRemoteControllers: Received from client: %v", in)
 	var result []models.BdevNvmeGetControllerResult
-	err := s.RPC.Call("bdev_nvme_get_controllers", nil, &result)
+	err := s.rpc.Call("bdev_nvme_get_controllers", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -108,7 +108,7 @@ func (s *Server) GetNVMfRemoteController(ctx context.Context, in *pb.GetNVMfRemo
 		Name: in.Name,
 	}
 	var result []models.BdevNvmeGetControllerResult
-	err := s.RPC.Call("bdev_nvme_get_controllers", &params, &result)
+	err := s.rpc.Call("bdev_nvme_get_controllers", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err

--- a/pkg/backend/nvme.go
+++ b/pkg/backend/nvme.go
@@ -14,7 +14,6 @@ import (
 	pc "github.com/opiproject/opi-api/common/v1/gen/go"
 	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
 	"github.com/opiproject/opi-spdk-bridge/pkg/models"
-	"github.com/opiproject/opi-spdk-bridge/pkg/server"
 
 	"github.com/ulule/deepcopier"
 	"google.golang.org/grpc/codes"
@@ -35,7 +34,7 @@ func (s *Server) CreateNVMfRemoteController(ctx context.Context, in *pb.CreateNV
 		Hostnqn: in.NvMfRemoteController.Hostnqn,
 	}
 	var result []models.BdevNvmeAttachControllerResult
-	err := server.Call("bdev_nvme_attach_controller", &params, &result)
+	err := s.RPC.Call("bdev_nvme_attach_controller", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -60,7 +59,7 @@ func (s *Server) DeleteNVMfRemoteController(ctx context.Context, in *pb.DeleteNV
 		Name: in.Name,
 	}
 	var result models.BdevNvmeDetachControllerResult
-	err := server.Call("bdev_nvme_detach_controller", &params, &result)
+	err := s.RPC.Call("bdev_nvme_detach_controller", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -79,7 +78,7 @@ func (s *Server) NVMfRemoteControllerReset(ctx context.Context, in *pb.NVMfRemot
 func (s *Server) ListNVMfRemoteControllers(ctx context.Context, in *pb.ListNVMfRemoteControllersRequest) (*pb.ListNVMfRemoteControllersResponse, error) {
 	log.Printf("ListNVMfRemoteControllers: Received from client: %v", in)
 	var result []models.BdevNvmeGetControllerResult
-	err := server.Call("bdev_nvme_get_controllers", nil, &result)
+	err := s.RPC.Call("bdev_nvme_get_controllers", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -109,7 +108,7 @@ func (s *Server) GetNVMfRemoteController(ctx context.Context, in *pb.GetNVMfRemo
 		Name: in.Name,
 	}
 	var result []models.BdevNvmeGetControllerResult
-	err := server.Call("bdev_nvme_get_controllers", &params, &result)
+	err := s.RPC.Call("bdev_nvme_get_controllers", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err

--- a/pkg/backend/nvme_test.go
+++ b/pkg/backend/nvme_test.go
@@ -19,7 +19,6 @@ import (
 
 	pc "github.com/opiproject/opi-api/common/v1/gen/go"
 	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
-	"github.com/opiproject/opi-spdk-bridge/pkg/server"
 )
 
 func TestBackEnd_CreateNVMfRemoteController(t *testing.T) {
@@ -88,21 +87,14 @@ func TestBackEnd_CreateNVMfRemoteController(t *testing.T) {
 		},
 	}
 
-	ctx, conn := startGrpcMockupServer()
-	defer server.CloseGrpcConnection(conn)
-	client := pb.NewNVMfRemoteControllerServiceClient(conn)
-
-	ln := server.StartSpdkMockupServer()
-	defer server.CloseListener(ln)
-
 	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.start {
-				go server.SpdkMockServer(ln, tt.spdk)
-			}
+			testEnv := createTestEnvironment(tt.start, tt.spdk)
+			defer testEnv.Close()
+
 			request := &pb.CreateNVMfRemoteControllerRequest{NvMfRemoteController: tt.in}
-			response, err := client.CreateNVMfRemoteController(ctx, request)
+			response, err := testEnv.client.CreateNVMfRemoteController(testEnv.ctx, request)
 			if response != nil {
 				// if !reflect.DeepEqual(response, tt.out) {
 				mtt, _ := proto.Marshal(tt.out)
@@ -147,21 +139,14 @@ func TestBackEnd_NVMfRemoteControllerReset(t *testing.T) {
 		},
 	}
 
-	ctx, conn := startGrpcMockupServer()
-	defer server.CloseGrpcConnection(conn)
-	client := pb.NewNVMfRemoteControllerServiceClient(conn)
-
-	ln := server.StartSpdkMockupServer()
-	defer server.CloseListener(ln)
-
 	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.start {
-				go server.SpdkMockServer(ln, tt.spdk)
-			}
+			testEnv := createTestEnvironment(tt.start, tt.spdk)
+			defer testEnv.Close()
+
 			request := &pb.NVMfRemoteControllerResetRequest{Id: &pc.ObjectKey{Value: tt.in}}
-			response, err := client.NVMfRemoteControllerReset(ctx, request)
+			response, err := testEnv.client.NVMfRemoteControllerReset(testEnv.ctx, request)
 			if response != nil {
 				// if !reflect.DeepEqual(response, tt.out) {
 				mtt, _ := proto.Marshal(tt.out)
@@ -270,21 +255,14 @@ func TestBackEnd_ListNVMfRemoteControllers(t *testing.T) {
 		},
 	}
 
-	ctx, conn := startGrpcMockupServer()
-	defer server.CloseGrpcConnection(conn)
-	client := pb.NewNVMfRemoteControllerServiceClient(conn)
-
-	ln := server.StartSpdkMockupServer()
-	defer server.CloseListener(ln)
-
 	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.start {
-				go server.SpdkMockServer(ln, tt.spdk)
-			}
+			testEnv := createTestEnvironment(tt.start, tt.spdk)
+			defer testEnv.Close()
+
 			request := &pb.ListNVMfRemoteControllersRequest{Parent: tt.in}
-			response, err := client.ListNVMfRemoteControllers(ctx, request)
+			response, err := testEnv.client.ListNVMfRemoteControllers(testEnv.ctx, request)
 			if response != nil {
 				if !reflect.DeepEqual(response.NvMfRemoteControllers, tt.out) {
 					t.Error("response: expected", tt.out, "received", response.NvMfRemoteControllers)
@@ -379,21 +357,14 @@ func TestBackEnd_GetNVMfRemoteController(t *testing.T) {
 		},
 	}
 
-	ctx, conn := startGrpcMockupServer()
-	defer server.CloseGrpcConnection(conn)
-	client := pb.NewNVMfRemoteControllerServiceClient(conn)
-
-	ln := server.StartSpdkMockupServer()
-	defer server.CloseListener(ln)
-
 	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.start {
-				go server.SpdkMockServer(ln, tt.spdk)
-			}
+			testEnv := createTestEnvironment(tt.start, tt.spdk)
+			defer testEnv.Close()
+
 			request := &pb.GetNVMfRemoteControllerRequest{Name: tt.in}
-			response, err := client.GetNVMfRemoteController(ctx, request)
+			response, err := testEnv.client.GetNVMfRemoteController(testEnv.ctx, request)
 			if response != nil {
 				// if !reflect.DeepEqual(response, tt.out) {
 				mtt, _ := proto.Marshal(tt.out)
@@ -441,21 +412,14 @@ func TestBackEnd_NVMfRemoteControllerStats(t *testing.T) {
 		},
 	}
 
-	ctx, conn := startGrpcMockupServer()
-	defer server.CloseGrpcConnection(conn)
-	client := pb.NewNVMfRemoteControllerServiceClient(conn)
-
-	ln := server.StartSpdkMockupServer()
-	defer server.CloseListener(ln)
-
 	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.start {
-				go server.SpdkMockServer(ln, tt.spdk)
-			}
+			testEnv := createTestEnvironment(tt.start, tt.spdk)
+			defer testEnv.Close()
+
 			request := &pb.NVMfRemoteControllerStatsRequest{Id: &pc.ObjectKey{Value: tt.in}}
-			response, err := client.NVMfRemoteControllerStats(ctx, request)
+			response, err := testEnv.client.NVMfRemoteControllerStats(testEnv.ctx, request)
 			if response != nil {
 				if !reflect.DeepEqual(response.Stats, tt.out) {
 					t.Error("response: expected", tt.out, "received", response)
@@ -542,21 +506,14 @@ func TestBackEnd_DeleteNVMfRemoteController(t *testing.T) {
 		},
 	}
 
-	ctx, conn := startGrpcMockupServer()
-	defer server.CloseGrpcConnection(conn)
-	client := pb.NewNVMfRemoteControllerServiceClient(conn)
-
-	ln := server.StartSpdkMockupServer()
-	defer server.CloseListener(ln)
-
 	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.start {
-				go server.SpdkMockServer(ln, tt.spdk)
-			}
+			testEnv := createTestEnvironment(tt.start, tt.spdk)
+			defer testEnv.Close()
+
 			request := &pb.DeleteNVMfRemoteControllerRequest{Name: tt.in}
-			response, err := client.DeleteNVMfRemoteController(ctx, request)
+			response, err := testEnv.client.DeleteNVMfRemoteController(testEnv.ctx, request)
 			if err != nil {
 				if er, ok := status.FromError(err); ok {
 					if er.Code() != tt.errCode {

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -39,7 +39,7 @@ type Server struct {
 	pb.UnimplementedFrontendVirtioBlkServiceServer
 	pb.UnimplementedFrontendVirtioScsiServiceServer
 
-	RPC  *server.JSONRPC
+	RPC  server.JSONRPC
 	Nvme NvmeParameters
 }
 
@@ -50,7 +50,7 @@ func NewServer() *Server {
 
 // NewServerWithJSONRPC creates initialized instance of FrontEnd server communicating
 // with provided jsonRPC
-func NewServerWithJSONRPC(jsonRPC *server.JSONRPC) *Server {
+func NewServerWithJSONRPC(jsonRPC server.JSONRPC) *Server {
 	return &Server{
 		RPC: jsonRPC,
 		Nvme: NvmeParameters{

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -39,7 +39,7 @@ type Server struct {
 	pb.UnimplementedFrontendVirtioBlkServiceServer
 	pb.UnimplementedFrontendVirtioScsiServiceServer
 
-	RPC  server.JSONRPC
+	rpc  server.JSONRPC
 	Nvme NvmeParameters
 }
 
@@ -52,7 +52,7 @@ func NewServer() *Server {
 // with provided jsonRPC
 func NewServerWithJSONRPC(jsonRPC server.JSONRPC) *Server {
 	return &Server{
-		RPC: jsonRPC,
+		rpc: jsonRPC,
 		Nvme: NvmeParameters{
 			Subsystems:  make(map[string]*pb.NVMeSubsystem),
 			Controllers: make(map[string]*pb.NVMeController),
@@ -69,7 +69,7 @@ func (s *Server) CreateVirtioBlk(ctx context.Context, in *pb.CreateVirtioBlkRequ
 		DevName: in.VirtioBlk.VolumeId.Value,
 	}
 	var result models.VhostCreateBlkControllerResult
-	err := s.RPC.Call("vhost_create_blk_controller", &params, &result)
+	err := s.rpc.Call("vhost_create_blk_controller", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, fmt.Errorf("%w for %v", errFailedSpdkCall, in)
@@ -96,7 +96,7 @@ func (s *Server) DeleteVirtioBlk(ctx context.Context, in *pb.DeleteVirtioBlkRequ
 		Ctrlr: in.Name,
 	}
 	var result models.VhostDeleteControllerResult
-	err := s.RPC.Call("vhost_delete_controller", &params, &result)
+	err := s.rpc.Call("vhost_delete_controller", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -118,7 +118,7 @@ func (s *Server) UpdateVirtioBlk(ctx context.Context, in *pb.UpdateVirtioBlkRequ
 func (s *Server) ListVirtioBlks(ctx context.Context, in *pb.ListVirtioBlksRequest) (*pb.ListVirtioBlksResponse, error) {
 	log.Printf("ListVirtioBlks: Received from client: %v", in)
 	var result []models.VhostGetControllersResult
-	err := s.RPC.Call("vhost_get_controllers", nil, &result)
+	err := s.rpc.Call("vhost_get_controllers", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -139,7 +139,7 @@ func (s *Server) GetVirtioBlk(ctx context.Context, in *pb.GetVirtioBlkRequest) (
 		Name: in.Name,
 	}
 	var result []models.VhostGetControllersResult
-	err := s.RPC.Call("vhost_get_controllers", &params, &result)
+	err := s.rpc.Call("vhost_get_controllers", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -41,7 +41,7 @@ type testEnv struct {
 	testSocket    string
 	ctx           context.Context
 	conn          *grpc.ClientConn
-	jsonRPC       *server.JSONRPC
+	jsonRPC       server.JSONRPC
 }
 
 func (e *testEnv) Close() {
@@ -55,7 +55,7 @@ func (e *testEnv) Close() {
 func createTestEnvironment(startSpdkServer bool, spdkResponses []string) *testEnv {
 	env := &testEnv{}
 	env.testSocket = server.GenerateSocketName("frontend")
-	env.jsonRPC = server.NewJSONRPC(env.testSocket)
+	env.ln, env.jsonRPC = server.CreateTestSpdkServer(env.testSocket, startSpdkServer, spdkResponses)
 	env.opiSpdkServer = NewServerWithJSONRPC(env.jsonRPC)
 
 	ctx := context.Background()
@@ -69,16 +69,12 @@ func createTestEnvironment(startSpdkServer bool, spdkResponses []string) *testEn
 	env.ctx = ctx
 	env.conn = conn
 
-	env.ln = server.StartSpdkMockupServer(env.jsonRPC)
 	env.client = &frontendClient{
 		pb.NewFrontendNvmeServiceClient(env.conn),
 		pb.NewFrontendVirtioBlkServiceClient(env.conn),
 		pb.NewFrontendVirtioScsiServiceClient(env.conn),
 	}
 
-	if startSpdkServer {
-		go server.SpdkMockServer(env.jsonRPC, env.ln, spdkResponses)
-	}
 	return env
 }
 

--- a/pkg/frontend/nvme.go
+++ b/pkg/frontend/nvme.go
@@ -14,7 +14,6 @@ import (
 	pc "github.com/opiproject/opi-api/common/v1/gen/go"
 	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
 	"github.com/opiproject/opi-spdk-bridge/pkg/models"
-	"github.com/opiproject/opi-spdk-bridge/pkg/server"
 
 	"github.com/ulule/deepcopier"
 	"google.golang.org/grpc/codes"
@@ -33,7 +32,7 @@ func (s *Server) CreateNVMeSubsystem(ctx context.Context, in *pb.CreateNVMeSubsy
 		MaxNamespaces: int(in.NvMeSubsystem.Spec.MaxNamespaces),
 	}
 	var result models.NvmfCreateSubsystemResult
-	err := server.Call("nvmf_create_subsystem", &params, &result)
+	err := s.RPC.Call("nvmf_create_subsystem", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -45,7 +44,7 @@ func (s *Server) CreateNVMeSubsystem(ctx context.Context, in *pb.CreateNVMeSubsy
 		return nil, status.Errorf(codes.InvalidArgument, msg)
 	}
 	var ver models.GetVersionResult
-	err = server.Call("spdk_get_version", nil, &ver)
+	err = s.RPC.Call("spdk_get_version", nil, &ver)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -75,7 +74,7 @@ func (s *Server) DeleteNVMeSubsystem(ctx context.Context, in *pb.DeleteNVMeSubsy
 		Nqn: subsys.Spec.Nqn,
 	}
 	var result models.NvmfDeleteSubsystemResult
-	err := server.Call("nvmf_delete_subsystem", &params, &result)
+	err := s.RPC.Call("nvmf_delete_subsystem", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -100,7 +99,7 @@ func (s *Server) UpdateNVMeSubsystem(ctx context.Context, in *pb.UpdateNVMeSubsy
 func (s *Server) ListNVMeSubsystems(ctx context.Context, in *pb.ListNVMeSubsystemsRequest) (*pb.ListNVMeSubsystemsResponse, error) {
 	log.Printf("ListNVMeSubsystems: Received from client: %v", in)
 	var result []models.NvmfGetSubsystemsResult
-	err := server.Call("nvmf_get_subsystems", nil, &result)
+	err := s.RPC.Call("nvmf_get_subsystems", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -125,7 +124,7 @@ func (s *Server) GetNVMeSubsystem(ctx context.Context, in *pb.GetNVMeSubsystemRe
 	}
 
 	var result []models.NvmfGetSubsystemsResult
-	err := server.Call("nvmf_get_subsystems", nil, &result)
+	err := s.RPC.Call("nvmf_get_subsystems", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -147,7 +146,7 @@ func (s *Server) GetNVMeSubsystem(ctx context.Context, in *pb.GetNVMeSubsystemRe
 func (s *Server) NVMeSubsystemStats(ctx context.Context, in *pb.NVMeSubsystemStatsRequest) (*pb.NVMeSubsystemStatsResponse, error) {
 	log.Printf("NVMeSubsystemStats: Received from client: %v", in)
 	var result models.NvmfGetSubsystemStatsResult
-	err := server.Call("nvmf_get_stats", nil, &result)
+	err := s.RPC.Call("nvmf_get_stats", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -182,7 +181,7 @@ func (s *Server) CreateNVMeController(ctx context.Context, in *pb.CreateNVMeCont
 	params.ListenAddress.Adrfam = "ipv4"
 
 	var result models.NvmfSubsystemAddListenerResult
-	err = server.Call("nvmf_subsystem_add_listener", &params, &result)
+	err = s.RPC.Call("nvmf_subsystem_add_listener", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -236,7 +235,7 @@ func (s *Server) DeleteNVMeController(ctx context.Context, in *pb.DeleteNVMeCont
 	params.ListenAddress.Adrfam = "ipv4"
 
 	var result models.NvmfSubsystemAddListenerResult
-	err = server.Call("nvmf_subsystem_remove_listener", &params, &result)
+	err = s.RPC.Call("nvmf_subsystem_remove_listener", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -310,7 +309,7 @@ func (s *Server) CreateNVMeNamespace(ctx context.Context, in *pb.CreateNVMeNames
 	params.Namespace.BdevName = in.NvMeNamespace.Spec.VolumeId.Value
 
 	var result models.NvmfSubsystemAddNsResult
-	err := server.Call("nvmf_subsystem_add_ns", &params, &result)
+	err := s.RPC.Call("nvmf_subsystem_add_ns", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -354,7 +353,7 @@ func (s *Server) DeleteNVMeNamespace(ctx context.Context, in *pb.DeleteNVMeNames
 		Nsid: int(namespace.Spec.HostNsid),
 	}
 	var result models.NvmfSubsystemRemoveNsResult
-	err := server.Call("nvmf_subsystem_remove_ns", &params, &result)
+	err := s.RPC.Call("nvmf_subsystem_remove_ns", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -399,7 +398,7 @@ func (s *Server) ListNVMeNamespaces(ctx context.Context, in *pb.ListNVMeNamespac
 		nqn = subsys.Spec.Nqn
 	}
 	var result []models.NvmfGetSubsystemsResult
-	err := server.Call("nvmf_get_subsystems", nil, &result)
+	err := s.RPC.Call("nvmf_get_subsystems", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -446,7 +445,7 @@ func (s *Server) GetNVMeNamespace(ctx context.Context, in *pb.GetNVMeNamespaceRe
 	}
 
 	var result []models.NvmfGetSubsystemsResult
-	err := server.Call("nvmf_get_subsystems", nil, &result)
+	err := s.RPC.Call("nvmf_get_subsystems", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err

--- a/pkg/frontend/nvme.go
+++ b/pkg/frontend/nvme.go
@@ -32,7 +32,7 @@ func (s *Server) CreateNVMeSubsystem(ctx context.Context, in *pb.CreateNVMeSubsy
 		MaxNamespaces: int(in.NvMeSubsystem.Spec.MaxNamespaces),
 	}
 	var result models.NvmfCreateSubsystemResult
-	err := s.RPC.Call("nvmf_create_subsystem", &params, &result)
+	err := s.rpc.Call("nvmf_create_subsystem", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -44,7 +44,7 @@ func (s *Server) CreateNVMeSubsystem(ctx context.Context, in *pb.CreateNVMeSubsy
 		return nil, status.Errorf(codes.InvalidArgument, msg)
 	}
 	var ver models.GetVersionResult
-	err = s.RPC.Call("spdk_get_version", nil, &ver)
+	err = s.rpc.Call("spdk_get_version", nil, &ver)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -74,7 +74,7 @@ func (s *Server) DeleteNVMeSubsystem(ctx context.Context, in *pb.DeleteNVMeSubsy
 		Nqn: subsys.Spec.Nqn,
 	}
 	var result models.NvmfDeleteSubsystemResult
-	err := s.RPC.Call("nvmf_delete_subsystem", &params, &result)
+	err := s.rpc.Call("nvmf_delete_subsystem", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -99,7 +99,7 @@ func (s *Server) UpdateNVMeSubsystem(ctx context.Context, in *pb.UpdateNVMeSubsy
 func (s *Server) ListNVMeSubsystems(ctx context.Context, in *pb.ListNVMeSubsystemsRequest) (*pb.ListNVMeSubsystemsResponse, error) {
 	log.Printf("ListNVMeSubsystems: Received from client: %v", in)
 	var result []models.NvmfGetSubsystemsResult
-	err := s.RPC.Call("nvmf_get_subsystems", nil, &result)
+	err := s.rpc.Call("nvmf_get_subsystems", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -124,7 +124,7 @@ func (s *Server) GetNVMeSubsystem(ctx context.Context, in *pb.GetNVMeSubsystemRe
 	}
 
 	var result []models.NvmfGetSubsystemsResult
-	err := s.RPC.Call("nvmf_get_subsystems", nil, &result)
+	err := s.rpc.Call("nvmf_get_subsystems", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -146,7 +146,7 @@ func (s *Server) GetNVMeSubsystem(ctx context.Context, in *pb.GetNVMeSubsystemRe
 func (s *Server) NVMeSubsystemStats(ctx context.Context, in *pb.NVMeSubsystemStatsRequest) (*pb.NVMeSubsystemStatsResponse, error) {
 	log.Printf("NVMeSubsystemStats: Received from client: %v", in)
 	var result models.NvmfGetSubsystemStatsResult
-	err := s.RPC.Call("nvmf_get_stats", nil, &result)
+	err := s.rpc.Call("nvmf_get_stats", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -181,7 +181,7 @@ func (s *Server) CreateNVMeController(ctx context.Context, in *pb.CreateNVMeCont
 	params.ListenAddress.Adrfam = "ipv4"
 
 	var result models.NvmfSubsystemAddListenerResult
-	err = s.RPC.Call("nvmf_subsystem_add_listener", &params, &result)
+	err = s.rpc.Call("nvmf_subsystem_add_listener", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -235,7 +235,7 @@ func (s *Server) DeleteNVMeController(ctx context.Context, in *pb.DeleteNVMeCont
 	params.ListenAddress.Adrfam = "ipv4"
 
 	var result models.NvmfSubsystemAddListenerResult
-	err = s.RPC.Call("nvmf_subsystem_remove_listener", &params, &result)
+	err = s.rpc.Call("nvmf_subsystem_remove_listener", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -309,7 +309,7 @@ func (s *Server) CreateNVMeNamespace(ctx context.Context, in *pb.CreateNVMeNames
 	params.Namespace.BdevName = in.NvMeNamespace.Spec.VolumeId.Value
 
 	var result models.NvmfSubsystemAddNsResult
-	err := s.RPC.Call("nvmf_subsystem_add_ns", &params, &result)
+	err := s.rpc.Call("nvmf_subsystem_add_ns", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -353,7 +353,7 @@ func (s *Server) DeleteNVMeNamespace(ctx context.Context, in *pb.DeleteNVMeNames
 		Nsid: int(namespace.Spec.HostNsid),
 	}
 	var result models.NvmfSubsystemRemoveNsResult
-	err := s.RPC.Call("nvmf_subsystem_remove_ns", &params, &result)
+	err := s.rpc.Call("nvmf_subsystem_remove_ns", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -398,7 +398,7 @@ func (s *Server) ListNVMeNamespaces(ctx context.Context, in *pb.ListNVMeNamespac
 		nqn = subsys.Spec.Nqn
 	}
 	var result []models.NvmfGetSubsystemsResult
-	err := s.RPC.Call("nvmf_get_subsystems", nil, &result)
+	err := s.rpc.Call("nvmf_get_subsystems", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -445,7 +445,7 @@ func (s *Server) GetNVMeNamespace(ctx context.Context, in *pb.GetNVMeNamespaceRe
 	}
 
 	var result []models.NvmfGetSubsystemsResult
-	err := s.RPC.Call("nvmf_get_subsystems", nil, &result)
+	err := s.rpc.Call("nvmf_get_subsystems", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err

--- a/pkg/frontend/nvme_test.go
+++ b/pkg/frontend/nvme_test.go
@@ -425,7 +425,7 @@ func TestFrontEnd_GetNVMeSubsystem(t *testing.T) {
 		},
 	}
 
-	opiSpdkServer := NewServer()
+	opiSpdkServer := NewServerWithJSONRPC(server.DefaultJSONRPC)
 	opiSpdkServer.Nvme.Subsystems[testSubsystem.Spec.Id.Value] = &testSubsystem
 	ctx, conn := startPreConfiguredGrpcMockupServer(opiSpdkServer)
 
@@ -663,7 +663,7 @@ func TestFrontEnd_CreateNVMeController(t *testing.T) {
 		},
 	}
 
-	opiSpdkServer := NewServer()
+	opiSpdkServer := NewServerWithJSONRPC(server.DefaultJSONRPC)
 	opiSpdkServer.Nvme.Subsystems[testSubsystem.Spec.Id.Value] = &testSubsystem
 	ctx, conn := startPreConfiguredGrpcMockupServer(opiSpdkServer)
 	defer server.CloseGrpcConnection(conn)
@@ -813,7 +813,7 @@ func TestFrontEnd_ListNVMeControllers(t *testing.T) {
 		},
 	}
 
-	opiSpdkServer := NewServer()
+	opiSpdkServer := NewServerWithJSONRPC(server.DefaultJSONRPC)
 	opiSpdkServer.Nvme.Subsystems[testSubsystem.Spec.Id.Value] = &testSubsystem
 	opiSpdkServer.Nvme.Controllers[testController.Spec.Id.Value] = &testController
 	ctx, conn := startPreConfiguredGrpcMockupServer(opiSpdkServer)
@@ -889,7 +889,7 @@ func TestFrontEnd_GetNVMeController(t *testing.T) {
 		},
 	}
 
-	opiSpdkServer := NewServer()
+	opiSpdkServer := NewServerWithJSONRPC(server.DefaultJSONRPC)
 	opiSpdkServer.Nvme.Subsystems[testSubsystem.Spec.Id.Value] = &testSubsystem
 	opiSpdkServer.Nvme.Controllers[testController.Spec.Id.Value] = &testController
 	ctx, conn := startPreConfiguredGrpcMockupServer(opiSpdkServer)
@@ -1080,7 +1080,7 @@ func TestFrontEnd_CreateNVMeNamespace(t *testing.T) {
 		},
 	}
 
-	opiSpdkServer := NewServer()
+	opiSpdkServer := NewServerWithJSONRPC(server.DefaultJSONRPC)
 	opiSpdkServer.Nvme.Subsystems[testSubsystem.Spec.Id.Value] = &testSubsystem
 	opiSpdkServer.Nvme.Controllers[testController.Spec.Id.Value] = &testController
 	ctx, conn := startPreConfiguredGrpcMockupServer(opiSpdkServer)
@@ -1303,7 +1303,7 @@ func TestFrontEnd_ListNVMeNamespaces(t *testing.T) {
 		},
 	}
 
-	opiSpdkServer := NewServer()
+	opiSpdkServer := NewServerWithJSONRPC(server.DefaultJSONRPC)
 	opiSpdkServer.Nvme.Subsystems[testSubsystem.Spec.Id.Value] = &testSubsystem
 	opiSpdkServer.Nvme.Controllers[testController.Spec.Id.Value] = &testController
 	opiSpdkServer.Nvme.Namespaces["ns0"] = &testNamespaces[0]
@@ -1428,7 +1428,7 @@ func TestFrontEnd_GetNVMeNamespace(t *testing.T) {
 		},
 	}
 
-	opiSpdkServer := NewServer()
+	opiSpdkServer := NewServerWithJSONRPC(server.DefaultJSONRPC)
 	opiSpdkServer.Nvme.Subsystems[testSubsystem.Spec.Id.Value] = &testSubsystem
 	opiSpdkServer.Nvme.Controllers[testController.Spec.Id.Value] = &testController
 	opiSpdkServer.Nvme.Namespaces[testNamespace.Spec.Id.Value] = &testNamespace
@@ -1595,7 +1595,7 @@ func TestFrontEnd_DeleteNVMeNamespace(t *testing.T) {
 		},
 	}
 
-	opiSpdkServer := NewServer()
+	opiSpdkServer := NewServerWithJSONRPC(server.DefaultJSONRPC)
 	opiSpdkServer.Nvme.Subsystems[testSubsystem.Spec.Id.Value] = &testSubsystem
 	opiSpdkServer.Nvme.Controllers[testController.Spec.Id.Value] = &testController
 	opiSpdkServer.Nvme.Namespaces[testNamespace.Spec.Id.Value] = &testNamespace
@@ -1697,7 +1697,7 @@ func TestFrontEnd_DeleteNVMeController(t *testing.T) {
 		},
 	}
 
-	opiSpdkServer := NewServer()
+	opiSpdkServer := NewServerWithJSONRPC(server.DefaultJSONRPC)
 	opiSpdkServer.Nvme.Subsystems[testSubsystem.Spec.Id.Value] = &testSubsystem
 	opiSpdkServer.Nvme.Controllers[testController.Spec.Id.Value] = &testController
 	ctx, conn := startPreConfiguredGrpcMockupServer(opiSpdkServer)
@@ -1798,7 +1798,7 @@ func TestFrontEnd_DeleteNVMeSubsystem(t *testing.T) {
 		},
 	}
 
-	opiSpdkServer := NewServer()
+	opiSpdkServer := NewServerWithJSONRPC(server.DefaultJSONRPC)
 	opiSpdkServer.Nvme.Subsystems[testSubsystem.Spec.Id.Value] = &testSubsystem
 	ctx, conn := startPreConfiguredGrpcMockupServer(opiSpdkServer)
 	defer server.CloseGrpcConnection(conn)

--- a/pkg/frontend/scsi.go
+++ b/pkg/frontend/scsi.go
@@ -27,7 +27,7 @@ func (s *Server) CreateVirtioScsiController(ctx context.Context, in *pb.CreateVi
 		Ctrlr: in.VirtioScsiController.Id.Value,
 	}
 	var result models.VhostCreateScsiControllerResult
-	err := s.RPC.Call("vhost_create_scsi_controller", &params, &result)
+	err := s.rpc.Call("vhost_create_scsi_controller", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -52,7 +52,7 @@ func (s *Server) DeleteVirtioScsiController(ctx context.Context, in *pb.DeleteVi
 		Ctrlr: in.Name,
 	}
 	var result models.VhostDeleteControllerResult
-	err := s.RPC.Call("vhost_delete_controller", &params, &result)
+	err := s.rpc.Call("vhost_delete_controller", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -74,7 +74,7 @@ func (s *Server) UpdateVirtioScsiController(ctx context.Context, in *pb.UpdateVi
 func (s *Server) ListVirtioScsiControllers(ctx context.Context, in *pb.ListVirtioScsiControllersRequest) (*pb.ListVirtioScsiControllersResponse, error) {
 	log.Printf("ListVirtioScsiControllers: Received from client: %v", in)
 	var result []models.VhostGetControllersResult
-	err := s.RPC.Call("vhost_get_controllers", nil, &result)
+	err := s.rpc.Call("vhost_get_controllers", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -95,7 +95,7 @@ func (s *Server) GetVirtioScsiController(ctx context.Context, in *pb.GetVirtioSc
 		Name: in.Name,
 	}
 	var result []models.VhostGetControllersResult
-	err := s.RPC.Call("vhost_get_controllers", &params, &result)
+	err := s.rpc.Call("vhost_get_controllers", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -128,7 +128,7 @@ func (s *Server) CreateVirtioScsiLun(ctx context.Context, in *pb.CreateVirtioScs
 		Bdev: in.VirtioScsiLun.VolumeId.Value,
 	}
 	var result int
-	err := s.RPC.Call("vhost_scsi_controller_add_target", &params, &result)
+	err := s.rpc.Call("vhost_scsi_controller_add_target", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -148,7 +148,7 @@ func (s *Server) DeleteVirtioScsiLun(ctx context.Context, in *pb.DeleteVirtioScs
 		Num:  5,
 	}
 	var result bool
-	err := s.RPC.Call("vhost_scsi_controller_remove_target", &params, &result)
+	err := s.rpc.Call("vhost_scsi_controller_remove_target", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -170,7 +170,7 @@ func (s *Server) UpdateVirtioScsiLun(ctx context.Context, in *pb.UpdateVirtioScs
 func (s *Server) ListVirtioScsiLuns(ctx context.Context, in *pb.ListVirtioScsiLunsRequest) (*pb.ListVirtioScsiLunsResponse, error) {
 	log.Printf("ListVirtioScsiLuns: Received from client: %v", in)
 	var result []models.VhostGetControllersResult
-	err := s.RPC.Call("vhost_get_controllers", nil, &result)
+	err := s.rpc.Call("vhost_get_controllers", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -191,7 +191,7 @@ func (s *Server) GetVirtioScsiLun(ctx context.Context, in *pb.GetVirtioScsiLunRe
 		Name: in.Name,
 	}
 	var result []models.VhostGetControllersResult
-	err := s.RPC.Call("vhost_get_controllers", &params, &result)
+	err := s.rpc.Call("vhost_get_controllers", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err

--- a/pkg/frontend/scsi.go
+++ b/pkg/frontend/scsi.go
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2022 Dell Inc, or its subsidiaries.
+// Copyright (C) 2023 Intel Corporation
 
-// Package frontend implememnts the FrontEnd APIs (host facing) of the storage Server
+// Package frontend implements the FrontEnd APIs (host facing) of the storage Server
 package frontend
 
 import (
@@ -12,7 +13,6 @@ import (
 	pc "github.com/opiproject/opi-api/common/v1/gen/go"
 	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
 	"github.com/opiproject/opi-spdk-bridge/pkg/models"
-	"github.com/opiproject/opi-spdk-bridge/pkg/server"
 
 	"github.com/ulule/deepcopier"
 	"google.golang.org/grpc/codes"
@@ -27,7 +27,7 @@ func (s *Server) CreateVirtioScsiController(ctx context.Context, in *pb.CreateVi
 		Ctrlr: in.VirtioScsiController.Id.Value,
 	}
 	var result models.VhostCreateScsiControllerResult
-	err := server.Call("vhost_create_scsi_controller", &params, &result)
+	err := s.RPC.Call("vhost_create_scsi_controller", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -52,7 +52,7 @@ func (s *Server) DeleteVirtioScsiController(ctx context.Context, in *pb.DeleteVi
 		Ctrlr: in.Name,
 	}
 	var result models.VhostDeleteControllerResult
-	err := server.Call("vhost_delete_controller", &params, &result)
+	err := s.RPC.Call("vhost_delete_controller", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -74,7 +74,7 @@ func (s *Server) UpdateVirtioScsiController(ctx context.Context, in *pb.UpdateVi
 func (s *Server) ListVirtioScsiControllers(ctx context.Context, in *pb.ListVirtioScsiControllersRequest) (*pb.ListVirtioScsiControllersResponse, error) {
 	log.Printf("ListVirtioScsiControllers: Received from client: %v", in)
 	var result []models.VhostGetControllersResult
-	err := server.Call("vhost_get_controllers", nil, &result)
+	err := s.RPC.Call("vhost_get_controllers", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -95,7 +95,7 @@ func (s *Server) GetVirtioScsiController(ctx context.Context, in *pb.GetVirtioSc
 		Name: in.Name,
 	}
 	var result []models.VhostGetControllersResult
-	err := server.Call("vhost_get_controllers", &params, &result)
+	err := s.RPC.Call("vhost_get_controllers", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -128,7 +128,7 @@ func (s *Server) CreateVirtioScsiLun(ctx context.Context, in *pb.CreateVirtioScs
 		Bdev: in.VirtioScsiLun.VolumeId.Value,
 	}
 	var result int
-	err := server.Call("vhost_scsi_controller_add_target", &params, &result)
+	err := s.RPC.Call("vhost_scsi_controller_add_target", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -148,7 +148,7 @@ func (s *Server) DeleteVirtioScsiLun(ctx context.Context, in *pb.DeleteVirtioScs
 		Num:  5,
 	}
 	var result bool
-	err := server.Call("vhost_scsi_controller_remove_target", &params, &result)
+	err := s.RPC.Call("vhost_scsi_controller_remove_target", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -170,7 +170,7 @@ func (s *Server) UpdateVirtioScsiLun(ctx context.Context, in *pb.UpdateVirtioScs
 func (s *Server) ListVirtioScsiLuns(ctx context.Context, in *pb.ListVirtioScsiLunsRequest) (*pb.ListVirtioScsiLunsResponse, error) {
 	log.Printf("ListVirtioScsiLuns: Received from client: %v", in)
 	var result []models.VhostGetControllersResult
-	err := server.Call("vhost_get_controllers", nil, &result)
+	err := s.RPC.Call("vhost_get_controllers", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -191,7 +191,7 @@ func (s *Server) GetVirtioScsiLun(ctx context.Context, in *pb.GetVirtioScsiLunRe
 		Name: in.Name,
 	}
 	var result []models.VhostGetControllersResult
-	err := server.Call("vhost_get_controllers", &params, &result)
+	err := s.RPC.Call("vhost_get_controllers", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err

--- a/pkg/middleend/middleend.go
+++ b/pkg/middleend/middleend.go
@@ -27,7 +27,7 @@ import (
 type Server struct {
 	pb.UnimplementedMiddleendServiceServer
 
-	RPC *server.JSONRPC
+	RPC server.JSONRPC
 }
 
 // NewServer creates initialized instance of MiddleEnd server
@@ -37,7 +37,7 @@ func NewServer() *Server {
 
 // NewServerWithJSONRPC creates initialized instance of MiddleEnd server communicating
 // with provided jsonRPC
-func NewServerWithJSONRPC(jsonRPC *server.JSONRPC) *Server {
+func NewServerWithJSONRPC(jsonRPC server.JSONRPC) *Server {
 	return &Server{
 		RPC: jsonRPC,
 	}

--- a/pkg/middleend/middleend.go
+++ b/pkg/middleend/middleend.go
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2022 Dell Inc, or its subsidiaries.
+// Copyright (C) 2023 Intel Corporation
 
-// Package middleend implememnts the MiddleEnd APIs (service) of the storage Server
+// Package middleend implements the MiddleEnd APIs (service) of the storage Server
 package middleend
 
 import (
@@ -25,11 +26,21 @@ import (
 // Server contains middleend related OPI services
 type Server struct {
 	pb.UnimplementedMiddleendServiceServer
+
+	RPC *server.JSONRPC
 }
 
 // NewServer creates initialized instance of MiddleEnd server
 func NewServer() *Server {
-	return &Server{}
+	return NewServerWithJSONRPC(server.DefaultJSONRPC)
+}
+
+// NewServerWithJSONRPC creates initialized instance of MiddleEnd server communicating
+// with provided jsonRPC
+func NewServerWithJSONRPC(jsonRPC *server.JSONRPC) *Server {
+	return &Server{
+		RPC: jsonRPC,
+	}
 }
 
 // CreateEncryptedVolume creates an encrypted volume
@@ -50,7 +61,7 @@ func (s *Server) CreateEncryptedVolume(ctx context.Context, in *pb.CreateEncrypt
 	}
 	// TODO: don't use hard-coded key name
 	var result1 models.AccelCryptoKeyCreateResult
-	err1 := server.Call("accel_crypto_key_create", &params1, &result1)
+	err1 := s.RPC.Call("accel_crypto_key_create", &params1, &result1)
 	if err1 != nil {
 		log.Printf("error: %v", err1)
 		return nil, err1
@@ -68,7 +79,7 @@ func (s *Server) CreateEncryptedVolume(ctx context.Context, in *pb.CreateEncrypt
 		KeyName:      "super_key",
 	}
 	var result models.BdevCryptoCreateResult
-	err := server.Call("bdev_crypto_create", &params, &result)
+	err := s.RPC.Call("bdev_crypto_create", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -95,7 +106,7 @@ func (s *Server) DeleteEncryptedVolume(ctx context.Context, in *pb.DeleteEncrypt
 		Name: in.Name,
 	}
 	var result models.BdevCryptoDeleteResult
-	err := server.Call("bdev_crypto_delete", &params, &result)
+	err := s.RPC.Call("bdev_crypto_delete", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -117,7 +128,7 @@ func (s *Server) UpdateEncryptedVolume(ctx context.Context, in *pb.UpdateEncrypt
 		Name: in.EncryptedVolume.EncryptedVolumeId.Value,
 	}
 	var result1 models.BdevCryptoDeleteResult
-	err1 := server.Call("bdev_crypto_delete", &params1, &result1)
+	err1 := s.RPC.Call("bdev_crypto_delete", &params1, &result1)
 	if err1 != nil {
 		log.Printf("error: %v", err1)
 		return nil, err1
@@ -131,7 +142,7 @@ func (s *Server) UpdateEncryptedVolume(ctx context.Context, in *pb.UpdateEncrypt
 		KeyName: "super_key",
 	}
 	var result0 models.AccelCryptoKeyDestroyResult
-	err0 := server.Call("accel_crypto_key_destroy", &params0, &result0)
+	err0 := s.RPC.Call("accel_crypto_key_destroy", &params0, &result0)
 	if err0 != nil {
 		log.Printf("error: %v", err0)
 		return nil, err0
@@ -155,7 +166,7 @@ func (s *Server) UpdateEncryptedVolume(ctx context.Context, in *pb.UpdateEncrypt
 	}
 	// TODO: don't use hard-coded key name
 	var result2 models.AccelCryptoKeyCreateResult
-	err2 := server.Call("accel_crypto_key_create", &params2, &result2)
+	err2 := s.RPC.Call("accel_crypto_key_create", &params2, &result2)
 	if err2 != nil {
 		log.Printf("error: %v", err2)
 		return nil, err2
@@ -173,7 +184,7 @@ func (s *Server) UpdateEncryptedVolume(ctx context.Context, in *pb.UpdateEncrypt
 		KeyName:      "super_key",
 	}
 	var result3 models.BdevCryptoCreateResult
-	err3 := server.Call("bdev_crypto_create", &params3, &result3)
+	err3 := s.RPC.Call("bdev_crypto_create", &params3, &result3)
 	if err3 != nil {
 		log.Printf("error: %v", err3)
 		return nil, err3
@@ -198,7 +209,7 @@ func (s *Server) UpdateEncryptedVolume(ctx context.Context, in *pb.UpdateEncrypt
 func (s *Server) ListEncryptedVolumes(ctx context.Context, in *pb.ListEncryptedVolumesRequest) (*pb.ListEncryptedVolumesResponse, error) {
 	log.Printf("ListEncryptedVolumes: Received from client: %v", in)
 	var result []models.BdevGetBdevsResult
-	err := server.Call("bdev_get_bdevs", nil, &result)
+	err := s.RPC.Call("bdev_get_bdevs", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -219,7 +230,7 @@ func (s *Server) GetEncryptedVolume(ctx context.Context, in *pb.GetEncryptedVolu
 		Name: in.Name,
 	}
 	var result []models.BdevGetBdevsResult
-	err := server.Call("bdev_get_bdevs", &params, &result)
+	err := s.RPC.Call("bdev_get_bdevs", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -241,7 +252,7 @@ func (s *Server) EncryptedVolumeStats(ctx context.Context, in *pb.EncryptedVolum
 	}
 	// See https://mholt.github.io/json-to-go/
 	var result models.BdevGetIostatResult
-	err := server.Call("bdev_get_iostat", &params, &result)
+	err := s.RPC.Call("bdev_get_iostat", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err

--- a/pkg/middleend/middleend.go
+++ b/pkg/middleend/middleend.go
@@ -27,7 +27,7 @@ import (
 type Server struct {
 	pb.UnimplementedMiddleendServiceServer
 
-	RPC server.JSONRPC
+	rpc server.JSONRPC
 }
 
 // NewServer creates initialized instance of MiddleEnd server
@@ -39,7 +39,7 @@ func NewServer() *Server {
 // with provided jsonRPC
 func NewServerWithJSONRPC(jsonRPC server.JSONRPC) *Server {
 	return &Server{
-		RPC: jsonRPC,
+		rpc: jsonRPC,
 	}
 }
 
@@ -61,7 +61,7 @@ func (s *Server) CreateEncryptedVolume(ctx context.Context, in *pb.CreateEncrypt
 	}
 	// TODO: don't use hard-coded key name
 	var result1 models.AccelCryptoKeyCreateResult
-	err1 := s.RPC.Call("accel_crypto_key_create", &params1, &result1)
+	err1 := s.rpc.Call("accel_crypto_key_create", &params1, &result1)
 	if err1 != nil {
 		log.Printf("error: %v", err1)
 		return nil, err1
@@ -79,7 +79,7 @@ func (s *Server) CreateEncryptedVolume(ctx context.Context, in *pb.CreateEncrypt
 		KeyName:      "super_key",
 	}
 	var result models.BdevCryptoCreateResult
-	err := s.RPC.Call("bdev_crypto_create", &params, &result)
+	err := s.rpc.Call("bdev_crypto_create", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -106,7 +106,7 @@ func (s *Server) DeleteEncryptedVolume(ctx context.Context, in *pb.DeleteEncrypt
 		Name: in.Name,
 	}
 	var result models.BdevCryptoDeleteResult
-	err := s.RPC.Call("bdev_crypto_delete", &params, &result)
+	err := s.rpc.Call("bdev_crypto_delete", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -128,7 +128,7 @@ func (s *Server) UpdateEncryptedVolume(ctx context.Context, in *pb.UpdateEncrypt
 		Name: in.EncryptedVolume.EncryptedVolumeId.Value,
 	}
 	var result1 models.BdevCryptoDeleteResult
-	err1 := s.RPC.Call("bdev_crypto_delete", &params1, &result1)
+	err1 := s.rpc.Call("bdev_crypto_delete", &params1, &result1)
 	if err1 != nil {
 		log.Printf("error: %v", err1)
 		return nil, err1
@@ -142,7 +142,7 @@ func (s *Server) UpdateEncryptedVolume(ctx context.Context, in *pb.UpdateEncrypt
 		KeyName: "super_key",
 	}
 	var result0 models.AccelCryptoKeyDestroyResult
-	err0 := s.RPC.Call("accel_crypto_key_destroy", &params0, &result0)
+	err0 := s.rpc.Call("accel_crypto_key_destroy", &params0, &result0)
 	if err0 != nil {
 		log.Printf("error: %v", err0)
 		return nil, err0
@@ -166,7 +166,7 @@ func (s *Server) UpdateEncryptedVolume(ctx context.Context, in *pb.UpdateEncrypt
 	}
 	// TODO: don't use hard-coded key name
 	var result2 models.AccelCryptoKeyCreateResult
-	err2 := s.RPC.Call("accel_crypto_key_create", &params2, &result2)
+	err2 := s.rpc.Call("accel_crypto_key_create", &params2, &result2)
 	if err2 != nil {
 		log.Printf("error: %v", err2)
 		return nil, err2
@@ -184,7 +184,7 @@ func (s *Server) UpdateEncryptedVolume(ctx context.Context, in *pb.UpdateEncrypt
 		KeyName:      "super_key",
 	}
 	var result3 models.BdevCryptoCreateResult
-	err3 := s.RPC.Call("bdev_crypto_create", &params3, &result3)
+	err3 := s.rpc.Call("bdev_crypto_create", &params3, &result3)
 	if err3 != nil {
 		log.Printf("error: %v", err3)
 		return nil, err3
@@ -209,7 +209,7 @@ func (s *Server) UpdateEncryptedVolume(ctx context.Context, in *pb.UpdateEncrypt
 func (s *Server) ListEncryptedVolumes(ctx context.Context, in *pb.ListEncryptedVolumesRequest) (*pb.ListEncryptedVolumesResponse, error) {
 	log.Printf("ListEncryptedVolumes: Received from client: %v", in)
 	var result []models.BdevGetBdevsResult
-	err := s.RPC.Call("bdev_get_bdevs", nil, &result)
+	err := s.rpc.Call("bdev_get_bdevs", nil, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -230,7 +230,7 @@ func (s *Server) GetEncryptedVolume(ctx context.Context, in *pb.GetEncryptedVolu
 		Name: in.Name,
 	}
 	var result []models.BdevGetBdevsResult
-	err := s.RPC.Call("bdev_get_bdevs", &params, &result)
+	err := s.rpc.Call("bdev_get_bdevs", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
@@ -252,7 +252,7 @@ func (s *Server) EncryptedVolumeStats(ctx context.Context, in *pb.EncryptedVolum
 	}
 	// See https://mholt.github.io/json-to-go/
 	var result models.BdevGetIostatResult
-	err := s.RPC.Call("bdev_get_iostat", &params, &result)
+	err := s.rpc.Call("bdev_get_iostat", &params, &result)
 	if err != nil {
 		log.Printf("error: %v", err)
 		return nil, err

--- a/pkg/middleend/middleend_test.go
+++ b/pkg/middleend/middleend_test.go
@@ -39,7 +39,7 @@ type testEnv struct {
 	testSocket    string
 	ctx           context.Context
 	conn          *grpc.ClientConn
-	jsonRPC       *server.JSONRPC
+	jsonRPC       server.JSONRPC
 }
 
 func (e *testEnv) Close() {
@@ -53,7 +53,7 @@ func (e *testEnv) Close() {
 func createTestEnvironment(startSpdkServer bool, spdkResponses []string) *testEnv {
 	env := &testEnv{}
 	env.testSocket = server.GenerateSocketName("middleend")
-	env.jsonRPC = server.NewJSONRPC(env.testSocket)
+	env.ln, env.jsonRPC = server.CreateTestSpdkServer(env.testSocket, startSpdkServer, spdkResponses)
 	env.opiSpdkServer = NewServerWithJSONRPC(env.jsonRPC)
 
 	ctx := context.Background()
@@ -67,14 +67,10 @@ func createTestEnvironment(startSpdkServer bool, spdkResponses []string) *testEn
 	env.ctx = ctx
 	env.conn = conn
 
-	env.ln = server.StartSpdkMockupServer(env.jsonRPC)
 	env.client = &middleendClient{
 		pb.NewMiddleendServiceClient(env.conn),
 	}
 
-	if startSpdkServer {
-		go server.SpdkMockServer(env.jsonRPC, env.ln, spdkResponses)
-	}
 	return env
 }
 

--- a/pkg/server/jsonrpc.go
+++ b/pkg/server/jsonrpc.go
@@ -24,7 +24,7 @@ type JSONRPC interface {
 }
 
 type unixSocketJSONRPC struct {
-	socket string
+	socket *string
 	id     uint64
 }
 
@@ -32,7 +32,7 @@ type unixSocketJSONRPC struct {
 // interact with unix domain socket
 func NewUnixSocketJSONRPC(socketPath string) JSONRPC {
 	return &unixSocketJSONRPC{
-		socket: socketPath,
+		socket: &socketPath,
 		id:     0,
 	}
 }
@@ -41,9 +41,13 @@ func NewUnixSocketJSONRPC(socketPath string) JSONRPC {
 var RPCSock = flag.String("rpc_sock", "/var/tmp/spdk.sock", "Path to SPDK JSON RPC socket")
 
 // DefaultJSONRPC is a default JSON RPC provider
-var DefaultJSONRPC = NewUnixSocketJSONRPC("/var/tmp/spdk.sock")
+var DefaultJSONRPC = &unixSocketJSONRPC{
+	socket: RPCSock,
+	id:     0,
+}
 
 // Call implements low level rpc request/response handling
+// Deprecated: JSONRPC structure should be instantiated and used.
 func Call(method string, args, result interface{}) error {
 	return DefaultJSONRPC.Call(method, args, result)
 }
@@ -65,7 +69,7 @@ func (r *unixSocketJSONRPC) Call(method string, args, result interface{}) error 
 	log.Printf("Sending to SPDK: %s", data)
 
 	// TODO: add also web option: resp, _ = webSocketCom(rpcClient, data)
-	resp, _ := unixSocketCom(r.socket, data)
+	resp, _ := unixSocketCom(*r.socket, data)
 
 	var response models.RPCResponse
 	err = json.NewDecoder(resp).Decode(&response)

--- a/pkg/server/jsonrpc.go
+++ b/pkg/server/jsonrpc.go
@@ -18,15 +18,20 @@ import (
 	"github.com/opiproject/opi-spdk-bridge/pkg/models"
 )
 
-// JSONRPC represents a structure to execute JSON RPC to SPDK
-type JSONRPC struct {
+// JSONRPC represents an interface to execute JSON RPC to SPDK
+type JSONRPC interface {
+	Call(method string, args, result interface{}) error
+}
+
+type unixSocketJSONRPC struct {
 	socket string
 	id     uint64
 }
 
-// NewJSONRPC creates a new instance of JsonRpc
-func NewJSONRPC(socketPath string) *JSONRPC {
-	return &JSONRPC{
+// NewUnixSocketJSONRPC creates a new instance of JSONRPC which is capable to
+// interact with unix domain socket
+func NewUnixSocketJSONRPC(socketPath string) JSONRPC {
+	return &unixSocketJSONRPC{
 		socket: socketPath,
 		id:     0,
 	}
@@ -36,7 +41,7 @@ func NewJSONRPC(socketPath string) *JSONRPC {
 var RPCSock = flag.String("rpc_sock", "/var/tmp/spdk.sock", "Path to SPDK JSON RPC socket")
 
 // DefaultJSONRPC is a default JSON RPC provider
-var DefaultJSONRPC = NewJSONRPC("/var/tmp/spdk.sock")
+var DefaultJSONRPC = NewUnixSocketJSONRPC("/var/tmp/spdk.sock")
 
 // Call implements low level rpc request/response handling
 func Call(method string, args, result interface{}) error {
@@ -44,7 +49,7 @@ func Call(method string, args, result interface{}) error {
 }
 
 // Call implements low level rpc request/response handling
-func (r *JSONRPC) Call(method string, args, result interface{}) error {
+func (r *unixSocketJSONRPC) Call(method string, args, result interface{}) error {
 	id := atomic.AddUint64(&r.id, 1)
 	request := models.RPCRequest{
 		RPCVersion: models.JSONRPCVersion,

--- a/pkg/server/jsonrpc.go
+++ b/pkg/server/jsonrpc.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2022 Dell Inc, or its subsidiaries.
+// Copyright (C) 2023 Intel Corporation
 
 // Package server implements the server
 package server
@@ -17,16 +18,34 @@ import (
 	"github.com/opiproject/opi-spdk-bridge/pkg/models"
 )
 
-var (
-	// RPCID is json request message ID, auto incremented
-	RPCID uint64
-	// RPCSock is unix domain socket to communicate with SPDK app or Vendor SDK
-	RPCSock = flag.String("rpc_sock", "/var/tmp/spdk.sock", "Path to SPDK JSON RPC socket")
-)
+// JSONRPC represents a structure to execute JSON RPC to SPDK
+type JSONRPC struct {
+	socket string
+	id     uint64
+}
+
+// NewJSONRPC creates a new instance of JsonRpc
+func NewJSONRPC(socketPath string) *JSONRPC {
+	return &JSONRPC{
+		socket: socketPath,
+		id:     0,
+	}
+}
+
+// RPCSock is unix domain socket to communicate with SPDK app or Vendor SDK
+var RPCSock = flag.String("rpc_sock", "/var/tmp/spdk.sock", "Path to SPDK JSON RPC socket")
+
+// DefaultJSONRPC is a default JSON RPC provider
+var DefaultJSONRPC = NewJSONRPC("/var/tmp/spdk.sock")
 
 // Call implements low level rpc request/response handling
 func Call(method string, args, result interface{}) error {
-	id := atomic.AddUint64(&RPCID, 1)
+	return DefaultJSONRPC.Call(method, args, result)
+}
+
+// Call implements low level rpc request/response handling
+func (r *JSONRPC) Call(method string, args, result interface{}) error {
+	id := atomic.AddUint64(&r.id, 1)
 	request := models.RPCRequest{
 		RPCVersion: models.JSONRPCVersion,
 		ID:         id,
@@ -41,7 +60,7 @@ func Call(method string, args, result interface{}) error {
 	log.Printf("Sending to SPDK: %s", data)
 
 	// TODO: add also web option: resp, _ = webSocketCom(rpcClient, data)
-	resp, _ := unixSocketCom(*RPCSock, data)
+	resp, _ := unixSocketCom(r.socket, data)
 
 	var response models.RPCResponse
 	err = json.NewDecoder(resp).Decode(&response)

--- a/pkg/server/utils.go
+++ b/pkg/server/utils.go
@@ -18,10 +18,10 @@ import (
 // StartSpdkMockupServer cleans unix socket and listens again, used in testing
 func StartSpdkMockupServer() net.Listener {
 	// start SPDK mockup Server
-	if err := os.RemoveAll(*RPCSock); err != nil {
+	if err := os.RemoveAll(DefaultJSONRPC.socket); err != nil {
 		log.Fatal(err)
 	}
-	ln, err := net.Listen("unix", *RPCSock)
+	ln, err := net.Listen("unix", DefaultJSONRPC.socket)
 	if err != nil {
 		log.Fatal("listen error:", err)
 	}
@@ -36,7 +36,7 @@ func SpdkMockServer(l net.Listener, toSend []string) {
 			log.Fatal("accept error:", err)
 		}
 		log.Printf("SPDK mockup Server: client connected [%s]", fd.RemoteAddr().Network())
-		log.Printf("SPDK ID [%d]", RPCID)
+		log.Printf("SPDK ID [%d]", DefaultJSONRPC.id)
 
 		buf := make([]byte, 512)
 		nr, err := fd.Read(buf)
@@ -46,7 +46,7 @@ func SpdkMockServer(l net.Listener, toSend []string) {
 
 		data := buf[0:nr]
 		if strings.Contains(spdk, "%") {
-			spdk = fmt.Sprintf(spdk, RPCID)
+			spdk = fmt.Sprintf(spdk, DefaultJSONRPC.id)
 		}
 
 		log.Printf("SPDK mockup Server: got : %s", string(data))


### PR DESCRIPTION
In this change JSON RPC related global variables were moved into a dedicated structure. It makes design flexible and testable. In addition tests are reworked to create a new JSON RPC structure per test. It makes the tests hermetic and allows to run them in parallel.
Patch provides backward compatibility for other bridges til they reworked to use JSONRPC interface injection