### PR TITLE
Add virtio-blk to KVM server

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,7 +34,7 @@ func main() {
 	flag.StringVar(&qmpAddress, "qmp_addr", "127.0.0.1:5555", "Points to QMP unix socket/tcp socket to interact with. Valid only with -kvm option")
 
 	var ctrlrDir string
-	flag.StringVar(&ctrlrDir, "ctrlr_dir", "/var/tmp", "Directory with created SPDK device unix sockets. Valid only with -kvm option")
+	flag.StringVar(&ctrlrDir, "ctrlr_dir", "", "Directory with created SPDK device unix sockets (-S option in SPDK). Valid only with -kvm option")
 	flag.Parse()
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))

--- a/pkg/kvm/kvm.go
+++ b/pkg/kvm/kvm.go
@@ -6,13 +6,30 @@ package kvm
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"net"
+	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/opiproject/opi-spdk-bridge/pkg/frontend"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+)
+
+const (
+	tcpProtocol        = "tcp"
+	unixSocketProtocol = "unix"
+)
+
+var (
+	errAddChardevFailed       = status.Error(codes.FailedPrecondition, "couldn't add chardev")
+	errMonitorCreation        = status.Error(codes.Internal, "failed to create QEMU monitor")
+	errAddDeviceFailed        = status.Error(codes.FailedPrecondition, "couldn't add device")
 )
 
 // Server is a wrapper for default opi-spdk-bridge frontend which automates
@@ -22,23 +39,65 @@ type Server struct {
 
 	qmpAddress string
 	ctrlrDir   string
+	protocol   string
+	timeout    time.Duration
 }
 
 // NewServer creates instance of KvmServer
 func NewServer(s *frontend.Server, qmpAddress string, ctrlrDir string) *Server {
-	return &Server{s, qmpAddress, ctrlrDir}
+	if s == nil {
+		log.Fatalf("Frontend Server cannot be nil")
+	}
+
+	if qmpAddress == "" {
+		log.Fatalf("qmpAddress cannot be empty")
+	}
+
+	if ctrlrDir == "" {
+		log.Fatalf("ctrlrDir cannot be empty")
+	}
+
+	qmpProtocol, err := getProtocol(qmpAddress)
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+
+	timeout := 2 * time.Second
+	return &Server{s, qmpAddress, ctrlrDir, qmpProtocol, timeout}
 }
 
 // CreateVirtioBlk creates a virtio-blk device and attaches it to QEMU instance
 func (s *Server) CreateVirtioBlk(ctx context.Context, in *pb.CreateVirtioBlkRequest) (*pb.VirtioBlk, error) {
 	out, err := s.Server.CreateVirtioBlk(ctx, in)
 	if err != nil {
+		log.Println("Error running cmd on opi-spdk bridge:", err)
 		return out, err
 	}
 
-	ctrlr := filepath.Join(s.ctrlrDir, in.VirtioBlk.Id.Value)
-	log.Printf("Plugging virtio-blk %v to qemu over %v", ctrlr, s.qmpAddress)
-	log.Println("virtio-blk is plugged.")
+	id := out.Id.Value
+	mon, err := newMonitor(s.qmpAddress, s.protocol, s.timeout)
+	if err != nil {
+		log.Println("Couldn't create QEMU monitor")
+		_, _ = s.Server.DeleteVirtioBlk(context.Background(), &pb.DeleteVirtioBlkRequest{Name: id})
+		return nil, errMonitorCreation
+	}
+	defer mon.Disconnect()
+
+	ctrlr := filepath.Join(s.ctrlrDir, id)
+	chardevID := out.Id.Value
+	if err := mon.AddChardev(chardevID, ctrlr); err != nil {
+		log.Println("Couldn't add chardev:", err)
+		_, _ = s.Server.DeleteVirtioBlk(context.Background(), &pb.DeleteVirtioBlkRequest{Name: id})
+		return nil, errAddChardevFailed
+	}
+
+	if err = mon.AddVirtioBlkDevice(id, id); err != nil {
+		log.Println("Couldn't add device:", err)
+		_ = mon.DeleteChardev(id)
+		_, _ = s.Server.DeleteVirtioBlk(context.Background(), &pb.DeleteVirtioBlkRequest{Name: id})
+		return nil, errAddDeviceFailed
+	}
+
 	return out, nil
 }
 
@@ -48,4 +107,28 @@ func (s *Server) DeleteVirtioBlk(ctx context.Context, in *pb.DeleteVirtioBlkRequ
 	log.Printf("Unplugging virtio-blk %v from qemu over %v", ctrlr, s.qmpAddress)
 	log.Println("virtio-blk is unplugged.")
 	return s.Server.DeleteVirtioBlk(ctx, in)
+}
+
+func getProtocol(qmpAddress string) (string, error) {
+	if isUnixSocketPath(qmpAddress) {
+		return unixSocketProtocol, nil
+	} else if isTCPAddress(qmpAddress) {
+		return tcpProtocol, nil
+	}
+	return "", fmt.Errorf("unknown protocol for %v", qmpAddress)
+}
+
+func isUnixSocketPath(qmpAddress string) bool {
+	fileInfo, err := os.Stat(qmpAddress)
+	if os.IsNotExist(err) {
+		return false
+	} else if fileInfo.IsDir() {
+		return false
+	}
+	return true
+}
+
+func isTCPAddress(qmpAddress string) bool {
+	_, _, err := net.SplitHostPort(qmpAddress)
+	return err == nil
 }

--- a/pkg/kvm/monitor.go
+++ b/pkg/kvm/monitor.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2023 Intel Corporation
+
+// Package kvm automates plugging of SPDK devices to a QEMU instance
+package kvm
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/digitalocean/go-qemu/qmp"
+	qmpraw "github.com/digitalocean/go-qemu/qmp/raw"
+)
+
+// TODO: check for device existence to provide idempotence in all methods
+
+type monitor struct {
+	rmon    *qmpraw.Monitor
+	mon     qmp.Monitor
+	timeout time.Duration
+}
+
+func newMonitor(qmpAddress string, protocol string, timeout time.Duration) (*monitor, error) {
+	mon, err := qmp.NewSocketMonitor(protocol, qmpAddress, timeout)
+	if err != nil {
+		log.Printf("couldn't create QEMU monitor: %v", err)
+		return nil, err
+	}
+
+	if err := mon.Connect(); err != nil {
+		log.Printf("Failed to connect to QEMU: %v", err)
+		return nil, err
+	}
+
+	rawMon := qmpraw.NewMonitor(mon)
+	return &monitor{rawMon, mon, timeout}, nil
+}
+
+func (m *monitor) Disconnect() {
+	err := m.mon.Disconnect()
+	if err != nil {
+		log.Fatalf("Failed to disconnect QMP monitor %v", err)
+	}
+}
+
+func (m *monitor) AddChardev(id string, sockPath string) error {
+	server := false
+	socketBackend := qmpraw.ChardevBackendSocket{
+		Addr: qmpraw.SocketAddressLegacyUnix{
+			Path: sockPath},
+		Server: &server}
+	_, err := m.rmon.ChardevAdd(id, socketBackend)
+	return err
+}
+
+func (m *monitor) DeleteChardev(id string) error {
+	return m.rmon.ChardevRemove(id)
+}
+
+func (m *monitor) AddVirtioBlkDevice(id string, chardevID string) error {
+	qmpCmd := struct {
+		Driver  string  `json:"driver"`
+		ID      *string `json:"id,omitempty"`
+		Chardev *string `json:"chardev,omitempty"`
+	}{
+		Driver:  "vhost-user-blk-pci",
+		ID:      &id,
+		Chardev: &chardevID,
+	}
+	bs, err := json.Marshal(map[string]interface{}{
+		"execute":   "device_add",
+		"arguments": qmpCmd,
+	})
+	if err != nil {
+		log.Println("json marshalling error:", err)
+		return fmt.Errorf("couldn't create QMP command: %w", err)
+	}
+
+	log.Println("QMP command to send: ", string(bs))
+	raw, err := m.mon.Run(bs)
+	if err != nil {
+		log.Println("QMP error:", err)
+		return fmt.Errorf("couldn't run QMP command: %w", err)
+	}
+
+	response := string(raw)
+	log.Println("QMP response:", response)
+	if strings.Contains(response, "error") {
+		return fmt.Errorf("qemu cmd run error: %v", string(bs))
+	}
+
+	return nil
+}


### PR DESCRIPTION
In this PR communication with a QEMU instance is automated to plug/unplug SPDK virtio-blk devices on CreateVirtioBlk/DeleteVirtioBlk