### PR TITLE
TCP transport uses provided IPv4 address to listen on

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,6 +35,9 @@ func main() {
 
 	var ctrlrDir string
 	flag.StringVar(&ctrlrDir, "ctrlr_dir", "", "Directory with created SPDK device unix sockets (-S option in SPDK). Valid only with -kvm option")
+
+	var tcpTransportListenAddr string
+	flag.StringVar(&tcpTransportListenAddr, "tcp_traddr", "127.0.0.1", "ipv4 address to listen on for TCP transport")
 	flag.Parse()
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
@@ -44,7 +47,8 @@ func main() {
 	s := grpc.NewServer()
 
 	jsonRPC := server.NewSpdkJSONRPC(spdkAddress)
-	frontendServer := frontend.NewServer(jsonRPC)
+	frontendServer := frontend.NewServerWithSubsystemListener(jsonRPC,
+		frontend.NewTCPSubsystemListener(tcpTransportListenAddr))
 	backendServer := backend.NewServer(jsonRPC)
 	middleendServer := middleend.NewServer(jsonRPC)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     depends_on:
       spdk:
         condition: service_healthy
-    command: /opi-spdk-bridge -port=50051 -spdk_addr /var/tmp/spdk.sock
+    command: sh -c "/opi-spdk-bridge -port=50051 -spdk_addr /var/tmp/spdk.sock -tcp_traddr=$$(getent hosts spdk | awk '{ print $$1 }')"
     healthcheck:
       test: grpcurl -plaintext localhost:50051 list || exit 1
 

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -54,7 +54,7 @@ func NewServer(jsonRPC server.JSONRPC) *Server {
 			Subsystems:     make(map[string]*pb.NVMeSubsystem),
 			Controllers:    make(map[string]*pb.NVMeController),
 			Namespaces:     make(map[string]*pb.NVMeNamespace),
-			subsysListener: NewTCPSubsystemListener(),
+			subsysListener: NewTCPSubsystemListener("127.0.0.1"),
 		},
 		Virt: VirtioParameters{
 			BlkCtrls:  make(map[string]*pb.VirtioBlk),


### PR DESCRIPTION
net.LookupIP takes time to get resolved, which slows down frontend test execution. Instead, a stub call which returns a predefined value can be used to get a quicker feedback from the tests.