### PR TITLE
Use underscore for unused arguments.

### DIFF
--- a/pkg/backend/aio.go
+++ b/pkg/backend/aio.go
@@ -21,7 +21,7 @@ import (
 )
 
 // CreateAioController creates an Aio controller
-func (s *Server) CreateAioController(ctx context.Context, in *pb.CreateAioControllerRequest) (*pb.AioController, error) {
+func (s *Server) CreateAioController(_ context.Context, in *pb.CreateAioControllerRequest) (*pb.AioController, error) {
 	log.Printf("CreateAioController: Received from client: %v", in)
 	// idempotent API when called with same key, should return same object
 	volume, ok := s.Volumes.AioVolumes[in.AioController.Handle.Value]
@@ -58,7 +58,7 @@ func (s *Server) CreateAioController(ctx context.Context, in *pb.CreateAioContro
 }
 
 // DeleteAioController deletes an Aio controller
-func (s *Server) DeleteAioController(ctx context.Context, in *pb.DeleteAioControllerRequest) (*emptypb.Empty, error) {
+func (s *Server) DeleteAioController(_ context.Context, in *pb.DeleteAioControllerRequest) (*emptypb.Empty, error) {
 	log.Printf("DeleteAioController: Received from client: %v", in)
 	volume, ok := s.Volumes.AioVolumes[in.Name]
 	if !ok {
@@ -84,7 +84,7 @@ func (s *Server) DeleteAioController(ctx context.Context, in *pb.DeleteAioContro
 }
 
 // UpdateAioController updates an Aio controller
-func (s *Server) UpdateAioController(ctx context.Context, in *pb.UpdateAioControllerRequest) (*pb.AioController, error) {
+func (s *Server) UpdateAioController(_ context.Context, in *pb.UpdateAioControllerRequest) (*pb.AioController, error) {
 	log.Printf("UpdateAioController: Received from client: %v", in)
 	params1 := models.BdevAioDeleteParams{
 		Name: in.AioController.Handle.Value,
@@ -115,7 +115,7 @@ func (s *Server) UpdateAioController(ctx context.Context, in *pb.UpdateAioContro
 }
 
 // ListAioControllers lists Aio controllers
-func (s *Server) ListAioControllers(ctx context.Context, in *pb.ListAioControllersRequest) (*pb.ListAioControllersResponse, error) {
+func (s *Server) ListAioControllers(_ context.Context, in *pb.ListAioControllersRequest) (*pb.ListAioControllersResponse, error) {
 	log.Printf("ListAioControllers: Received from client: %v", in)
 	var result []models.BdevGetBdevsResult
 	err := s.rpc.Call("bdev_get_bdevs", nil, &result)
@@ -133,7 +133,7 @@ func (s *Server) ListAioControllers(ctx context.Context, in *pb.ListAioControlle
 }
 
 // GetAioController gets an Aio controller
-func (s *Server) GetAioController(ctx context.Context, in *pb.GetAioControllerRequest) (*pb.AioController, error) {
+func (s *Server) GetAioController(_ context.Context, in *pb.GetAioControllerRequest) (*pb.AioController, error) {
 	log.Printf("GetAioController: Received from client: %v", in)
 	params := models.BdevGetBdevsParams{
 		Name: in.Name,
@@ -154,7 +154,7 @@ func (s *Server) GetAioController(ctx context.Context, in *pb.GetAioControllerRe
 }
 
 // AioControllerStats gets an Aio controller stats
-func (s *Server) AioControllerStats(ctx context.Context, in *pb.AioControllerStatsRequest) (*pb.AioControllerStatsResponse, error) {
+func (s *Server) AioControllerStats(_ context.Context, in *pb.AioControllerStatsRequest) (*pb.AioControllerStatsResponse, error) {
 	log.Printf("AioControllerStats: Received from client: %v", in)
 	params := models.BdevGetIostatParams{
 		Name: in.GetHandle().GetValue(),

--- a/pkg/backend/aio_test.go
+++ b/pkg/backend/aio_test.go
@@ -119,7 +119,7 @@ func TestBackEnd_CreateAioController(t *testing.T) {
 	}
 }
 
-func TestBackEnd_UpdateAioController(t *testing.T) {
+func TestBackEnd_UpdateAioController(_ *testing.T) {
 
 }
 
@@ -224,11 +224,11 @@ func TestBackEnd_ListAioControllers(t *testing.T) {
 	}
 }
 
-func TestBackEnd_GetAioController(t *testing.T) {
+func TestBackEnd_GetAioController(_ *testing.T) {
 
 }
 
-func TestBackEnd_AioControllerStats(t *testing.T) {
+func TestBackEnd_AioControllerStats(_ *testing.T) {
 
 }
 

--- a/pkg/backend/null.go
+++ b/pkg/backend/null.go
@@ -21,7 +21,7 @@ import (
 )
 
 // CreateNullDebug creates a Null Debug instance
-func (s *Server) CreateNullDebug(ctx context.Context, in *pb.CreateNullDebugRequest) (*pb.NullDebug, error) {
+func (s *Server) CreateNullDebug(_ context.Context, in *pb.CreateNullDebugRequest) (*pb.NullDebug, error) {
 	log.Printf("CreateNullDebug: Received from client: %v", in)
 	// idempotent API when called with same key, should return same object
 	volume, ok := s.Volumes.NullVolumes[in.NullDebug.Handle.Value]
@@ -58,7 +58,7 @@ func (s *Server) CreateNullDebug(ctx context.Context, in *pb.CreateNullDebugRequ
 }
 
 // DeleteNullDebug deletes a Null Debug instance
-func (s *Server) DeleteNullDebug(ctx context.Context, in *pb.DeleteNullDebugRequest) (*emptypb.Empty, error) {
+func (s *Server) DeleteNullDebug(_ context.Context, in *pb.DeleteNullDebugRequest) (*emptypb.Empty, error) {
 	log.Printf("DeleteNullDebug: Received from client: %v", in)
 	volume, ok := s.Volumes.NullVolumes[in.Name]
 	if !ok {
@@ -84,7 +84,7 @@ func (s *Server) DeleteNullDebug(ctx context.Context, in *pb.DeleteNullDebugRequ
 }
 
 // UpdateNullDebug updates a Null Debug instance
-func (s *Server) UpdateNullDebug(ctx context.Context, in *pb.UpdateNullDebugRequest) (*pb.NullDebug, error) {
+func (s *Server) UpdateNullDebug(_ context.Context, in *pb.UpdateNullDebugRequest) (*pb.NullDebug, error) {
 	log.Printf("UpdateNullDebug: Received from client: %v", in)
 	params1 := models.BdevNullDeleteParams{
 		Name: in.NullDebug.Handle.Value,
@@ -121,7 +121,7 @@ func (s *Server) UpdateNullDebug(ctx context.Context, in *pb.UpdateNullDebugRequ
 }
 
 // ListNullDebugs lists Null Debug instances
-func (s *Server) ListNullDebugs(ctx context.Context, in *pb.ListNullDebugsRequest) (*pb.ListNullDebugsResponse, error) {
+func (s *Server) ListNullDebugs(_ context.Context, in *pb.ListNullDebugsRequest) (*pb.ListNullDebugsResponse, error) {
 	log.Printf("ListNullDebugs: Received from client: %v", in)
 	var result []models.BdevGetBdevsResult
 	err := s.rpc.Call("bdev_get_bdevs", nil, &result)
@@ -139,7 +139,7 @@ func (s *Server) ListNullDebugs(ctx context.Context, in *pb.ListNullDebugsReques
 }
 
 // GetNullDebug gets a a Null Debug instance
-func (s *Server) GetNullDebug(ctx context.Context, in *pb.GetNullDebugRequest) (*pb.NullDebug, error) {
+func (s *Server) GetNullDebug(_ context.Context, in *pb.GetNullDebugRequest) (*pb.NullDebug, error) {
 	log.Printf("GetNullDebug: Received from client: %v", in)
 	params := models.BdevGetBdevsParams{
 		Name: in.Name,
@@ -160,7 +160,7 @@ func (s *Server) GetNullDebug(ctx context.Context, in *pb.GetNullDebugRequest) (
 }
 
 // NullDebugStats gets a Null Debug instance stats
-func (s *Server) NullDebugStats(ctx context.Context, in *pb.NullDebugStatsRequest) (*pb.NullDebugStatsResponse, error) {
+func (s *Server) NullDebugStats(_ context.Context, in *pb.NullDebugStatsRequest) (*pb.NullDebugStatsResponse, error) {
 	log.Printf("NullDebugStats: Received from client: %v", in)
 	params := models.BdevGetIostatParams{
 		Name: in.Handle.Value,

--- a/pkg/backend/null_test.go
+++ b/pkg/backend/null_test.go
@@ -118,7 +118,7 @@ func TestBackEnd_CreateNullDebug(t *testing.T) {
 	}
 }
 
-func TestBackEnd_UpdateNullDebug(t *testing.T) {
+func TestBackEnd_UpdateNullDebug(_ *testing.T) {
 
 }
 
@@ -225,11 +225,11 @@ func TestBackEnd_ListNullDebugs(t *testing.T) {
 	}
 }
 
-func TestBackEnd_GetNullDebug(t *testing.T) {
+func TestBackEnd_GetNullDebug(_ *testing.T) {
 
 }
 
-func TestBackEnd_NullDebugStats(t *testing.T) {
+func TestBackEnd_NullDebugStats(_ *testing.T) {
 
 }
 

--- a/pkg/backend/nvme.go
+++ b/pkg/backend/nvme.go
@@ -22,7 +22,7 @@ import (
 )
 
 // CreateNVMfRemoteController creates an NVMf remote controller
-func (s *Server) CreateNVMfRemoteController(ctx context.Context, in *pb.CreateNVMfRemoteControllerRequest) (*pb.NVMfRemoteController, error) {
+func (s *Server) CreateNVMfRemoteController(_ context.Context, in *pb.CreateNVMfRemoteControllerRequest) (*pb.NVMfRemoteController, error) {
 	log.Printf("CreateNVMfRemoteController: Received from client: %v", in)
 	// idempotent API when called with same key, should return same object
 	volume, ok := s.Volumes.NvmeVolumes[in.NvMfRemoteController.Id.Value]
@@ -61,7 +61,7 @@ func (s *Server) CreateNVMfRemoteController(ctx context.Context, in *pb.CreateNV
 }
 
 // DeleteNVMfRemoteController deletes an NVMf remote controller
-func (s *Server) DeleteNVMfRemoteController(ctx context.Context, in *pb.DeleteNVMfRemoteControllerRequest) (*emptypb.Empty, error) {
+func (s *Server) DeleteNVMfRemoteController(_ context.Context, in *pb.DeleteNVMfRemoteControllerRequest) (*emptypb.Empty, error) {
 	log.Printf("DeleteNVMfRemoteController: Received from client: %v", in)
 	volume, ok := s.Volumes.NvmeVolumes[in.Name]
 	if !ok {
@@ -85,13 +85,13 @@ func (s *Server) DeleteNVMfRemoteController(ctx context.Context, in *pb.DeleteNV
 }
 
 // NVMfRemoteControllerReset resets an NVMf remote controller
-func (s *Server) NVMfRemoteControllerReset(ctx context.Context, in *pb.NVMfRemoteControllerResetRequest) (*emptypb.Empty, error) {
+func (s *Server) NVMfRemoteControllerReset(_ context.Context, in *pb.NVMfRemoteControllerResetRequest) (*emptypb.Empty, error) {
 	log.Printf("Received: %v", in.GetId())
 	return &emptypb.Empty{}, nil
 }
 
 // ListNVMfRemoteControllers lists an NVMf remote controllers
-func (s *Server) ListNVMfRemoteControllers(ctx context.Context, in *pb.ListNVMfRemoteControllersRequest) (*pb.ListNVMfRemoteControllersResponse, error) {
+func (s *Server) ListNVMfRemoteControllers(_ context.Context, in *pb.ListNVMfRemoteControllersRequest) (*pb.ListNVMfRemoteControllersResponse, error) {
 	log.Printf("ListNVMfRemoteControllers: Received from client: %v", in)
 	var result []models.BdevNvmeGetControllerResult
 	err := s.rpc.Call("bdev_nvme_get_controllers", nil, &result)
@@ -118,7 +118,7 @@ func (s *Server) ListNVMfRemoteControllers(ctx context.Context, in *pb.ListNVMfR
 }
 
 // GetNVMfRemoteController gets an NVMf remote controller
-func (s *Server) GetNVMfRemoteController(ctx context.Context, in *pb.GetNVMfRemoteControllerRequest) (*pb.NVMfRemoteController, error) {
+func (s *Server) GetNVMfRemoteController(_ context.Context, in *pb.GetNVMfRemoteControllerRequest) (*pb.NVMfRemoteController, error) {
 	log.Printf("GetNVMfRemoteController: Received from client: %v", in)
 	params := models.BdevNvmeGetControllerParams{
 		Name: in.Name,
@@ -148,7 +148,7 @@ func (s *Server) GetNVMfRemoteController(ctx context.Context, in *pb.GetNVMfRemo
 }
 
 // NVMfRemoteControllerStats gets NVMf remote controller stats
-func (s *Server) NVMfRemoteControllerStats(ctx context.Context, in *pb.NVMfRemoteControllerStatsRequest) (*pb.NVMfRemoteControllerStatsResponse, error) {
+func (s *Server) NVMfRemoteControllerStats(_ context.Context, in *pb.NVMfRemoteControllerStatsRequest) (*pb.NVMfRemoteControllerStatsResponse, error) {
 	log.Printf("Received: %v", in.GetId())
 	return &pb.NVMfRemoteControllerStatsResponse{Stats: &pb.VolumeStats{ReadOpsCount: -1, WriteOpsCount: -1}}, nil
 }

--- a/pkg/frontend/blk.go
+++ b/pkg/frontend/blk.go
@@ -22,7 +22,7 @@ import (
 )
 
 // CreateVirtioBlk creates a Virtio block device
-func (s *Server) CreateVirtioBlk(ctx context.Context, in *pb.CreateVirtioBlkRequest) (*pb.VirtioBlk, error) {
+func (s *Server) CreateVirtioBlk(_ context.Context, in *pb.CreateVirtioBlkRequest) (*pb.VirtioBlk, error) {
 	log.Printf("CreateVirtioBlk: Received from client: %v", in)
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.Virt.BlkCtrls[in.VirtioBlk.Id.Value]
@@ -58,7 +58,7 @@ func (s *Server) CreateVirtioBlk(ctx context.Context, in *pb.CreateVirtioBlkRequ
 }
 
 // DeleteVirtioBlk deletes a Virtio block device
-func (s *Server) DeleteVirtioBlk(ctx context.Context, in *pb.DeleteVirtioBlkRequest) (*emptypb.Empty, error) {
+func (s *Server) DeleteVirtioBlk(_ context.Context, in *pb.DeleteVirtioBlkRequest) (*emptypb.Empty, error) {
 	log.Printf("DeleteVirtioBlk: Received from client: %v", in)
 	controller, ok := s.Virt.BlkCtrls[in.Name]
 	if !ok {
@@ -82,13 +82,13 @@ func (s *Server) DeleteVirtioBlk(ctx context.Context, in *pb.DeleteVirtioBlkRequ
 }
 
 // UpdateVirtioBlk updates a Virtio block device
-func (s *Server) UpdateVirtioBlk(ctx context.Context, in *pb.UpdateVirtioBlkRequest) (*pb.VirtioBlk, error) {
+func (s *Server) UpdateVirtioBlk(_ context.Context, in *pb.UpdateVirtioBlkRequest) (*pb.VirtioBlk, error) {
 	log.Printf("UpdateVirtioBlk: Received from client: %v", in)
 	return nil, status.Errorf(codes.Unimplemented, "UpdateVirtioBlk method is not implemented")
 }
 
 // ListVirtioBlks lists Virtio block devices
-func (s *Server) ListVirtioBlks(ctx context.Context, in *pb.ListVirtioBlksRequest) (*pb.ListVirtioBlksResponse, error) {
+func (s *Server) ListVirtioBlks(_ context.Context, in *pb.ListVirtioBlksRequest) (*pb.ListVirtioBlksResponse, error) {
 	log.Printf("ListVirtioBlks: Received from client: %v", in)
 	var result []models.VhostGetControllersResult
 	err := s.rpc.Call("vhost_get_controllers", nil, &result)
@@ -109,7 +109,7 @@ func (s *Server) ListVirtioBlks(ctx context.Context, in *pb.ListVirtioBlksReques
 }
 
 // GetVirtioBlk gets a Virtio block device
-func (s *Server) GetVirtioBlk(ctx context.Context, in *pb.GetVirtioBlkRequest) (*pb.VirtioBlk, error) {
+func (s *Server) GetVirtioBlk(_ context.Context, in *pb.GetVirtioBlkRequest) (*pb.VirtioBlk, error) {
 	log.Printf("GetVirtioBlk: Received from client: %v", in)
 	_, ok := s.Virt.BlkCtrls[in.Name]
 	if !ok {
@@ -139,7 +139,7 @@ func (s *Server) GetVirtioBlk(ctx context.Context, in *pb.GetVirtioBlkRequest) (
 }
 
 // VirtioBlkStats gets a Virtio block device stats
-func (s *Server) VirtioBlkStats(ctx context.Context, in *pb.VirtioBlkStatsRequest) (*pb.VirtioBlkStatsResponse, error) {
+func (s *Server) VirtioBlkStats(_ context.Context, in *pb.VirtioBlkStatsRequest) (*pb.VirtioBlkStatsResponse, error) {
 	log.Printf("VirtioBlkStats: Received from client: %v", in)
 	return nil, status.Errorf(codes.Unimplemented, "VirtioBlkStats method is not implemented")
 }

--- a/pkg/frontend/nvme.go
+++ b/pkg/frontend/nvme.go
@@ -28,7 +28,7 @@ func NewTCPSubsystemListener() SubsystemListener {
 	return &tcpSubsystemListener{}
 }
 
-func (c *tcpSubsystemListener) Params(ctrlr *pb.NVMeController, nqn string) models.NvmfSubsystemAddListenerParams {
+func (c *tcpSubsystemListener) Params(_ *pb.NVMeController, nqn string) models.NvmfSubsystemAddListenerParams {
 	result := models.NvmfSubsystemAddListenerParams{}
 	addrs, err := net.LookupIP("spdk")
 	if err != nil {
@@ -46,7 +46,7 @@ func (c *tcpSubsystemListener) Params(ctrlr *pb.NVMeController, nqn string) mode
 }
 
 // CreateNVMeSubsystem creates an NVMe Subsystem
-func (s *Server) CreateNVMeSubsystem(ctx context.Context, in *pb.CreateNVMeSubsystemRequest) (*pb.NVMeSubsystem, error) {
+func (s *Server) CreateNVMeSubsystem(_ context.Context, in *pb.CreateNVMeSubsystemRequest) (*pb.NVMeSubsystem, error) {
 	log.Printf("CreateNVMeSubsystem: Received from client: %v", in)
 	// idempotent API when called with same key, should return same object
 	subsys, ok := s.Nvme.Subsystems[in.NvMeSubsystem.Spec.Id.Value]
@@ -93,7 +93,7 @@ func (s *Server) CreateNVMeSubsystem(ctx context.Context, in *pb.CreateNVMeSubsy
 }
 
 // DeleteNVMeSubsystem deletes an NVMe Subsystem
-func (s *Server) DeleteNVMeSubsystem(ctx context.Context, in *pb.DeleteNVMeSubsystemRequest) (*emptypb.Empty, error) {
+func (s *Server) DeleteNVMeSubsystem(_ context.Context, in *pb.DeleteNVMeSubsystemRequest) (*emptypb.Empty, error) {
 	log.Printf("DeleteNVMeSubsystem: Received from client: %v", in)
 	subsys, ok := s.Nvme.Subsystems[in.Name]
 	if !ok {
@@ -121,13 +121,13 @@ func (s *Server) DeleteNVMeSubsystem(ctx context.Context, in *pb.DeleteNVMeSubsy
 }
 
 // UpdateNVMeSubsystem updates an NVMe Subsystem
-func (s *Server) UpdateNVMeSubsystem(ctx context.Context, in *pb.UpdateNVMeSubsystemRequest) (*pb.NVMeSubsystem, error) {
+func (s *Server) UpdateNVMeSubsystem(_ context.Context, in *pb.UpdateNVMeSubsystemRequest) (*pb.NVMeSubsystem, error) {
 	log.Printf("UpdateNVMeSubsystem: Received from client: %v", in)
 	return nil, status.Errorf(codes.Unimplemented, "UpdateNVMeSubsystem method is not implemented")
 }
 
 // ListNVMeSubsystems lists NVMe Subsystems
-func (s *Server) ListNVMeSubsystems(ctx context.Context, in *pb.ListNVMeSubsystemsRequest) (*pb.ListNVMeSubsystemsResponse, error) {
+func (s *Server) ListNVMeSubsystems(_ context.Context, in *pb.ListNVMeSubsystemsRequest) (*pb.ListNVMeSubsystemsResponse, error) {
 	log.Printf("ListNVMeSubsystems: Received from client: %v", in)
 	var result []models.NvmfGetSubsystemsResult
 	err := s.rpc.Call("nvmf_get_subsystems", nil, &result)
@@ -145,7 +145,7 @@ func (s *Server) ListNVMeSubsystems(ctx context.Context, in *pb.ListNVMeSubsyste
 }
 
 // GetNVMeSubsystem gets NVMe Subsystems
-func (s *Server) GetNVMeSubsystem(ctx context.Context, in *pb.GetNVMeSubsystemRequest) (*pb.NVMeSubsystem, error) {
+func (s *Server) GetNVMeSubsystem(_ context.Context, in *pb.GetNVMeSubsystemRequest) (*pb.NVMeSubsystem, error) {
 	log.Printf("GetNVMeSubsystem: Received from client: %v", in)
 	subsys, ok := s.Nvme.Subsystems[in.Name]
 	if !ok {
@@ -174,7 +174,7 @@ func (s *Server) GetNVMeSubsystem(ctx context.Context, in *pb.GetNVMeSubsystemRe
 }
 
 // NVMeSubsystemStats gets NVMe Subsystem stats
-func (s *Server) NVMeSubsystemStats(ctx context.Context, in *pb.NVMeSubsystemStatsRequest) (*pb.NVMeSubsystemStatsResponse, error) {
+func (s *Server) NVMeSubsystemStats(_ context.Context, in *pb.NVMeSubsystemStatsRequest) (*pb.NVMeSubsystemStatsResponse, error) {
 	log.Printf("NVMeSubsystemStats: Received from client: %v", in)
 	var result models.NvmfGetSubsystemStatsResult
 	err := s.rpc.Call("nvmf_get_stats", nil, &result)
@@ -187,7 +187,7 @@ func (s *Server) NVMeSubsystemStats(ctx context.Context, in *pb.NVMeSubsystemSta
 }
 
 // CreateNVMeController creates an NVMe controller
-func (s *Server) CreateNVMeController(ctx context.Context, in *pb.CreateNVMeControllerRequest) (*pb.NVMeController, error) {
+func (s *Server) CreateNVMeController(_ context.Context, in *pb.CreateNVMeControllerRequest) (*pb.NVMeController, error) {
 	log.Printf("Received from client: %v", in.NvMeController)
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.Nvme.Controllers[in.NvMeController.Spec.Id.Value]
@@ -229,7 +229,7 @@ func (s *Server) CreateNVMeController(ctx context.Context, in *pb.CreateNVMeCont
 }
 
 // DeleteNVMeController deletes an NVMe controller
-func (s *Server) DeleteNVMeController(ctx context.Context, in *pb.DeleteNVMeControllerRequest) (*emptypb.Empty, error) {
+func (s *Server) DeleteNVMeController(_ context.Context, in *pb.DeleteNVMeControllerRequest) (*emptypb.Empty, error) {
 	log.Printf("Received from client: %v", in.Name)
 	controller, ok := s.Nvme.Controllers[in.Name]
 	if !ok {
@@ -260,7 +260,7 @@ func (s *Server) DeleteNVMeController(ctx context.Context, in *pb.DeleteNVMeCont
 }
 
 // UpdateNVMeController updates an NVMe controller
-func (s *Server) UpdateNVMeController(ctx context.Context, in *pb.UpdateNVMeControllerRequest) (*pb.NVMeController, error) {
+func (s *Server) UpdateNVMeController(_ context.Context, in *pb.UpdateNVMeControllerRequest) (*pb.NVMeController, error) {
 	log.Printf("UpdateNVMeController: Received from client: %v", in)
 	s.Nvme.Controllers[in.NvMeController.Spec.Id.Value] = in.NvMeController
 	s.Nvme.Controllers[in.NvMeController.Spec.Id.Value].Status = &pb.NVMeControllerStatus{Active: true}
@@ -274,7 +274,7 @@ func (s *Server) UpdateNVMeController(ctx context.Context, in *pb.UpdateNVMeCont
 }
 
 // ListNVMeControllers lists NVMe controllers
-func (s *Server) ListNVMeControllers(ctx context.Context, in *pb.ListNVMeControllersRequest) (*pb.ListNVMeControllersResponse, error) {
+func (s *Server) ListNVMeControllers(_ context.Context, in *pb.ListNVMeControllersRequest) (*pb.ListNVMeControllersResponse, error) {
 	log.Printf("Received from client: %v", in.Parent)
 	Blobarray := []*pb.NVMeController{}
 	for _, controller := range s.Nvme.Controllers {
@@ -284,7 +284,7 @@ func (s *Server) ListNVMeControllers(ctx context.Context, in *pb.ListNVMeControl
 }
 
 // GetNVMeController gets an NVMe controller
-func (s *Server) GetNVMeController(ctx context.Context, in *pb.GetNVMeControllerRequest) (*pb.NVMeController, error) {
+func (s *Server) GetNVMeController(_ context.Context, in *pb.GetNVMeControllerRequest) (*pb.NVMeController, error) {
 	log.Printf("Received from client: %v", in.Name)
 	controller, ok := s.Nvme.Controllers[in.Name]
 	if !ok {
@@ -294,13 +294,13 @@ func (s *Server) GetNVMeController(ctx context.Context, in *pb.GetNVMeController
 }
 
 // NVMeControllerStats gets an NVMe controller stats
-func (s *Server) NVMeControllerStats(ctx context.Context, in *pb.NVMeControllerStatsRequest) (*pb.NVMeControllerStatsResponse, error) {
+func (s *Server) NVMeControllerStats(_ context.Context, in *pb.NVMeControllerStatsRequest) (*pb.NVMeControllerStatsResponse, error) {
 	log.Printf("NVMeControllerStats: Received from client: %v", in)
 	return &pb.NVMeControllerStatsResponse{Stats: &pb.VolumeStats{ReadOpsCount: -1, WriteOpsCount: -1}}, nil
 }
 
 // CreateNVMeNamespace creates an NVMe namespace
-func (s *Server) CreateNVMeNamespace(ctx context.Context, in *pb.CreateNVMeNamespaceRequest) (*pb.NVMeNamespace, error) {
+func (s *Server) CreateNVMeNamespace(_ context.Context, in *pb.CreateNVMeNamespaceRequest) (*pb.NVMeNamespace, error) {
 	log.Printf("CreateNVMeNamespace: Received from client: %v", in)
 	// idempotent API when called with same key, should return same object
 	namespace, ok := s.Nvme.Namespaces[in.NvMeNamespace.Spec.Id.Value]
@@ -349,7 +349,7 @@ func (s *Server) CreateNVMeNamespace(ctx context.Context, in *pb.CreateNVMeNames
 }
 
 // DeleteNVMeNamespace deletes an NVMe namespace
-func (s *Server) DeleteNVMeNamespace(ctx context.Context, in *pb.DeleteNVMeNamespaceRequest) (*emptypb.Empty, error) {
+func (s *Server) DeleteNVMeNamespace(_ context.Context, in *pb.DeleteNVMeNamespaceRequest) (*emptypb.Empty, error) {
 	log.Printf("DeleteNVMeNamespace: Received from client: %v", in)
 	namespace, ok := s.Nvme.Namespaces[in.Name]
 	if !ok {
@@ -385,7 +385,7 @@ func (s *Server) DeleteNVMeNamespace(ctx context.Context, in *pb.DeleteNVMeNames
 }
 
 // UpdateNVMeNamespace updates an NVMe namespace
-func (s *Server) UpdateNVMeNamespace(ctx context.Context, in *pb.UpdateNVMeNamespaceRequest) (*pb.NVMeNamespace, error) {
+func (s *Server) UpdateNVMeNamespace(_ context.Context, in *pb.UpdateNVMeNamespaceRequest) (*pb.NVMeNamespace, error) {
 	log.Printf("UpdateNVMeNamespace: Received from client: %v", in)
 	s.Nvme.Namespaces[in.NvMeNamespace.Spec.Id.Value] = in.NvMeNamespace
 	s.Nvme.Namespaces[in.NvMeNamespace.Spec.Id.Value].Status = &pb.NVMeNamespaceStatus{PciState: 2, PciOperState: 1}
@@ -400,7 +400,7 @@ func (s *Server) UpdateNVMeNamespace(ctx context.Context, in *pb.UpdateNVMeNames
 }
 
 // ListNVMeNamespaces lists NVMe namespaces
-func (s *Server) ListNVMeNamespaces(ctx context.Context, in *pb.ListNVMeNamespacesRequest) (*pb.ListNVMeNamespacesResponse, error) {
+func (s *Server) ListNVMeNamespaces(_ context.Context, in *pb.ListNVMeNamespacesRequest) (*pb.ListNVMeNamespacesResponse, error) {
 	log.Printf("ListNVMeNamespaces: Received from client: %v", in)
 
 	nqn := ""
@@ -441,7 +441,7 @@ func (s *Server) ListNVMeNamespaces(ctx context.Context, in *pb.ListNVMeNamespac
 }
 
 // GetNVMeNamespace gets an NVMe namespace
-func (s *Server) GetNVMeNamespace(ctx context.Context, in *pb.GetNVMeNamespaceRequest) (*pb.NVMeNamespace, error) {
+func (s *Server) GetNVMeNamespace(_ context.Context, in *pb.GetNVMeNamespaceRequest) (*pb.NVMeNamespace, error) {
 	log.Printf("GetNVMeNamespace: Received from client: %v", in)
 	namespace, ok := s.Nvme.Namespaces[in.Name]
 	if !ok {
@@ -490,7 +490,7 @@ func (s *Server) GetNVMeNamespace(ctx context.Context, in *pb.GetNVMeNamespaceRe
 }
 
 // NVMeNamespaceStats gets an NVMe namespace stats
-func (s *Server) NVMeNamespaceStats(ctx context.Context, in *pb.NVMeNamespaceStatsRequest) (*pb.NVMeNamespaceStatsResponse, error) {
+func (s *Server) NVMeNamespaceStats(_ context.Context, in *pb.NVMeNamespaceStatsRequest) (*pb.NVMeNamespaceStatsResponse, error) {
 	log.Printf("NVMeNamespaceStats: Received from client: %v", in)
 	return &pb.NVMeNamespaceStatsResponse{Stats: &pb.VolumeStats{ReadOpsCount: -1, WriteOpsCount: -1}}, nil
 }

--- a/pkg/frontend/scsi.go
+++ b/pkg/frontend/scsi.go
@@ -21,7 +21,7 @@ import (
 )
 
 // CreateVirtioScsiController creates a Virtio SCSI controller
-func (s *Server) CreateVirtioScsiController(ctx context.Context, in *pb.CreateVirtioScsiControllerRequest) (*pb.VirtioScsiController, error) {
+func (s *Server) CreateVirtioScsiController(_ context.Context, in *pb.CreateVirtioScsiControllerRequest) (*pb.VirtioScsiController, error) {
 	log.Printf("CreateVirtioScsiController: Received from client: %v", in)
 	params := models.VhostCreateScsiControllerParams{
 		Ctrlr: in.VirtioScsiController.Id.Value,
@@ -46,7 +46,7 @@ func (s *Server) CreateVirtioScsiController(ctx context.Context, in *pb.CreateVi
 }
 
 // DeleteVirtioScsiController deletes a Virtio SCSI controller
-func (s *Server) DeleteVirtioScsiController(ctx context.Context, in *pb.DeleteVirtioScsiControllerRequest) (*emptypb.Empty, error) {
+func (s *Server) DeleteVirtioScsiController(_ context.Context, in *pb.DeleteVirtioScsiControllerRequest) (*emptypb.Empty, error) {
 	log.Printf("DeleteVirtioScsiController: Received from client: %v", in)
 	params := models.VhostDeleteControllerParams{
 		Ctrlr: in.Name,
@@ -65,13 +65,13 @@ func (s *Server) DeleteVirtioScsiController(ctx context.Context, in *pb.DeleteVi
 }
 
 // UpdateVirtioScsiController updates a Virtio SCSI controller
-func (s *Server) UpdateVirtioScsiController(ctx context.Context, in *pb.UpdateVirtioScsiControllerRequest) (*pb.VirtioScsiController, error) {
+func (s *Server) UpdateVirtioScsiController(_ context.Context, in *pb.UpdateVirtioScsiControllerRequest) (*pb.VirtioScsiController, error) {
 	log.Printf("Received from client: %v", in)
 	return &pb.VirtioScsiController{}, nil
 }
 
 // ListVirtioScsiControllers lists Virtio SCSI controllers
-func (s *Server) ListVirtioScsiControllers(ctx context.Context, in *pb.ListVirtioScsiControllersRequest) (*pb.ListVirtioScsiControllersResponse, error) {
+func (s *Server) ListVirtioScsiControllers(_ context.Context, in *pb.ListVirtioScsiControllersRequest) (*pb.ListVirtioScsiControllersResponse, error) {
 	log.Printf("ListVirtioScsiControllers: Received from client: %v", in)
 	var result []models.VhostGetControllersResult
 	err := s.rpc.Call("vhost_get_controllers", nil, &result)
@@ -89,7 +89,7 @@ func (s *Server) ListVirtioScsiControllers(ctx context.Context, in *pb.ListVirti
 }
 
 // GetVirtioScsiController gets a Virtio SCSI controller
-func (s *Server) GetVirtioScsiController(ctx context.Context, in *pb.GetVirtioScsiControllerRequest) (*pb.VirtioScsiController, error) {
+func (s *Server) GetVirtioScsiController(_ context.Context, in *pb.GetVirtioScsiControllerRequest) (*pb.VirtioScsiController, error) {
 	log.Printf("GetVirtioScsiController: Received from client: %v", in)
 	params := models.VhostGetControllersParams{
 		Name: in.Name,
@@ -110,13 +110,13 @@ func (s *Server) GetVirtioScsiController(ctx context.Context, in *pb.GetVirtioSc
 }
 
 // VirtioScsiControllerStats gets a Virtio SCSI controller stats
-func (s *Server) VirtioScsiControllerStats(ctx context.Context, in *pb.VirtioScsiControllerStatsRequest) (*pb.VirtioScsiControllerStatsResponse, error) {
+func (s *Server) VirtioScsiControllerStats(_ context.Context, in *pb.VirtioScsiControllerStatsRequest) (*pb.VirtioScsiControllerStatsResponse, error) {
 	log.Printf("Received from client: %v", in)
 	return &pb.VirtioScsiControllerStatsResponse{}, nil
 }
 
 // CreateVirtioScsiLun creates a Virtio SCSI LUN
-func (s *Server) CreateVirtioScsiLun(ctx context.Context, in *pb.CreateVirtioScsiLunRequest) (*pb.VirtioScsiLun, error) {
+func (s *Server) CreateVirtioScsiLun(_ context.Context, in *pb.CreateVirtioScsiLunRequest) (*pb.VirtioScsiLun, error) {
 	log.Printf("CreateVirtioScsiLun: Received from client: %v", in)
 	params := struct {
 		Name string `json:"ctrlr"`
@@ -138,7 +138,7 @@ func (s *Server) CreateVirtioScsiLun(ctx context.Context, in *pb.CreateVirtioScs
 }
 
 // DeleteVirtioScsiLun deletes a Virtio SCSI LUN
-func (s *Server) DeleteVirtioScsiLun(ctx context.Context, in *pb.DeleteVirtioScsiLunRequest) (*emptypb.Empty, error) {
+func (s *Server) DeleteVirtioScsiLun(_ context.Context, in *pb.DeleteVirtioScsiLunRequest) (*emptypb.Empty, error) {
 	log.Printf("DeleteVirtioScsiLun: Received from client: %v", in)
 	params := struct {
 		Name string `json:"ctrlr"`
@@ -161,13 +161,13 @@ func (s *Server) DeleteVirtioScsiLun(ctx context.Context, in *pb.DeleteVirtioScs
 }
 
 // UpdateVirtioScsiLun updates a Virtio SCSI LUN
-func (s *Server) UpdateVirtioScsiLun(ctx context.Context, in *pb.UpdateVirtioScsiLunRequest) (*pb.VirtioScsiLun, error) {
+func (s *Server) UpdateVirtioScsiLun(_ context.Context, in *pb.UpdateVirtioScsiLunRequest) (*pb.VirtioScsiLun, error) {
 	log.Printf("Received from client: %v", in)
 	return &pb.VirtioScsiLun{}, nil
 }
 
 // ListVirtioScsiLuns lists Virtio SCSI LUNs
-func (s *Server) ListVirtioScsiLuns(ctx context.Context, in *pb.ListVirtioScsiLunsRequest) (*pb.ListVirtioScsiLunsResponse, error) {
+func (s *Server) ListVirtioScsiLuns(_ context.Context, in *pb.ListVirtioScsiLunsRequest) (*pb.ListVirtioScsiLunsResponse, error) {
 	log.Printf("ListVirtioScsiLuns: Received from client: %v", in)
 	var result []models.VhostGetControllersResult
 	err := s.rpc.Call("vhost_get_controllers", nil, &result)
@@ -185,7 +185,7 @@ func (s *Server) ListVirtioScsiLuns(ctx context.Context, in *pb.ListVirtioScsiLu
 }
 
 // GetVirtioScsiLun gets a Virtio SCSI LUN
-func (s *Server) GetVirtioScsiLun(ctx context.Context, in *pb.GetVirtioScsiLunRequest) (*pb.VirtioScsiLun, error) {
+func (s *Server) GetVirtioScsiLun(_ context.Context, in *pb.GetVirtioScsiLunRequest) (*pb.VirtioScsiLun, error) {
 	log.Printf("GetVirtioScsiLun: Received from client: %v", in)
 	params := models.VhostGetControllersParams{
 		Name: in.Name,
@@ -206,7 +206,7 @@ func (s *Server) GetVirtioScsiLun(ctx context.Context, in *pb.GetVirtioScsiLunRe
 }
 
 // VirtioScsiLunStats gets a Virtio SCSI LUN stats
-func (s *Server) VirtioScsiLunStats(ctx context.Context, in *pb.VirtioScsiLunStatsRequest) (*pb.VirtioScsiLunStatsResponse, error) {
+func (s *Server) VirtioScsiLunStats(_ context.Context, in *pb.VirtioScsiLunStatsRequest) (*pb.VirtioScsiLunStatsResponse, error) {
 	log.Printf("Received from client: %v", in)
 	return &pb.VirtioScsiLunStatsResponse{}, nil
 }

--- a/pkg/frontend/scsi_test.go
+++ b/pkg/frontend/scsi_test.go
@@ -8,50 +8,50 @@ import (
 	"testing"
 )
 
-func TestFrontEnd_CreateVirtioScsiController(t *testing.T) {
+func TestFrontEnd_CreateVirtioScsiController(_ *testing.T) {
 
 }
 
-func TestFrontEnd_DeleteVirtioScsiController(t *testing.T) {
+func TestFrontEnd_DeleteVirtioScsiController(_ *testing.T) {
 
 }
 
-func TestFrontEnd_UpdateVirtioScsiController(t *testing.T) {
+func TestFrontEnd_UpdateVirtioScsiController(_ *testing.T) {
 
 }
 
-func TestFrontEnd_ListVirtioScsiControllers(t *testing.T) {
+func TestFrontEnd_ListVirtioScsiControllers(_ *testing.T) {
 
 }
 
-func TestFrontEnd_GetVirtioScsiController(t *testing.T) {
+func TestFrontEnd_GetVirtioScsiController(_ *testing.T) {
 
 }
 
-func TestFrontEnd_VirtioScsiControllerStats(t *testing.T) {
+func TestFrontEnd_VirtioScsiControllerStats(_ *testing.T) {
 
 }
 
-func TestFrontEnd_CreateVirtioScsiLun(t *testing.T) {
+func TestFrontEnd_CreateVirtioScsiLun(_ *testing.T) {
 
 }
 
-func TestFrontEnd_DeleteVirtioScsiLun(t *testing.T) {
+func TestFrontEnd_DeleteVirtioScsiLun(_ *testing.T) {
 
 }
 
-func TestFrontEnd_UpdateVirtioScsiLun(t *testing.T) {
+func TestFrontEnd_UpdateVirtioScsiLun(_ *testing.T) {
 
 }
 
-func TestFrontEnd_ListVirtioScsiLuns(t *testing.T) {
+func TestFrontEnd_ListVirtioScsiLuns(_ *testing.T) {
 
 }
 
-func TestFrontEnd_GetVirtioScsiLun(t *testing.T) {
+func TestFrontEnd_GetVirtioScsiLun(_ *testing.T) {
 
 }
 
-func TestFrontEnd_VirtioScsiLunStats(t *testing.T) {
+func TestFrontEnd_VirtioScsiLunStats(_ *testing.T) {
 
 }

--- a/pkg/kvm/kvm_test.go
+++ b/pkg/kvm/kvm_test.go
@@ -48,7 +48,7 @@ type stubJSONRRPC struct {
 	err error
 }
 
-func (s stubJSONRRPC) Call(method string, args, result interface{}) error {
+func (s stubJSONRRPC) Call(method string, _, result interface{}) error {
 	if method == "vhost_create_blk_controller" {
 		if s.err == nil {
 			resultCreateVirtioBLk, ok := result.(*models.VhostCreateBlkControllerResult)

--- a/pkg/middleend/middleend.go
+++ b/pkg/middleend/middleend.go
@@ -39,7 +39,7 @@ func NewServer(jsonRPC server.JSONRPC) *Server {
 }
 
 // CreateEncryptedVolume creates an encrypted volume
-func (s *Server) CreateEncryptedVolume(ctx context.Context, in *pb.CreateEncryptedVolumeRequest) (*pb.EncryptedVolume, error) {
+func (s *Server) CreateEncryptedVolume(_ context.Context, in *pb.CreateEncryptedVolumeRequest) (*pb.EncryptedVolume, error) {
 	log.Printf("CreateEncryptedVolume: Received from client: %v", in)
 	// first create a key
 	r := regexp.MustCompile("ENCRYPTION_TYPE_([A-Z_]+)_")
@@ -95,7 +95,7 @@ func (s *Server) CreateEncryptedVolume(ctx context.Context, in *pb.CreateEncrypt
 }
 
 // DeleteEncryptedVolume deletes an encrypted volume
-func (s *Server) DeleteEncryptedVolume(ctx context.Context, in *pb.DeleteEncryptedVolumeRequest) (*emptypb.Empty, error) {
+func (s *Server) DeleteEncryptedVolume(_ context.Context, in *pb.DeleteEncryptedVolumeRequest) (*emptypb.Empty, error) {
 	log.Printf("DeleteEncryptedVolume: Received from client: %v", in)
 	params := models.BdevCryptoDeleteParams{
 		Name: in.Name,
@@ -116,7 +116,7 @@ func (s *Server) DeleteEncryptedVolume(ctx context.Context, in *pb.DeleteEncrypt
 }
 
 // UpdateEncryptedVolume updates an encrypted volume
-func (s *Server) UpdateEncryptedVolume(ctx context.Context, in *pb.UpdateEncryptedVolumeRequest) (*pb.EncryptedVolume, error) {
+func (s *Server) UpdateEncryptedVolume(_ context.Context, in *pb.UpdateEncryptedVolumeRequest) (*pb.EncryptedVolume, error) {
 	log.Printf("UpdateEncryptedVolume: Received from client: %v", in)
 	// first delete old bdev
 	params1 := models.BdevCryptoDeleteParams{
@@ -201,7 +201,7 @@ func (s *Server) UpdateEncryptedVolume(ctx context.Context, in *pb.UpdateEncrypt
 }
 
 // ListEncryptedVolumes lists encrypted volumes
-func (s *Server) ListEncryptedVolumes(ctx context.Context, in *pb.ListEncryptedVolumesRequest) (*pb.ListEncryptedVolumesResponse, error) {
+func (s *Server) ListEncryptedVolumes(_ context.Context, in *pb.ListEncryptedVolumesRequest) (*pb.ListEncryptedVolumesResponse, error) {
 	log.Printf("ListEncryptedVolumes: Received from client: %v", in)
 	var result []models.BdevGetBdevsResult
 	err := s.rpc.Call("bdev_get_bdevs", nil, &result)
@@ -219,7 +219,7 @@ func (s *Server) ListEncryptedVolumes(ctx context.Context, in *pb.ListEncryptedV
 }
 
 // GetEncryptedVolume gets an encrypted volume
-func (s *Server) GetEncryptedVolume(ctx context.Context, in *pb.GetEncryptedVolumeRequest) (*pb.EncryptedVolume, error) {
+func (s *Server) GetEncryptedVolume(_ context.Context, in *pb.GetEncryptedVolumeRequest) (*pb.EncryptedVolume, error) {
 	log.Printf("GetEncryptedVolume: Received from client: %v", in)
 	params := models.BdevGetBdevsParams{
 		Name: in.Name,
@@ -240,7 +240,7 @@ func (s *Server) GetEncryptedVolume(ctx context.Context, in *pb.GetEncryptedVolu
 }
 
 // EncryptedVolumeStats gets an encrypted volume stats
-func (s *Server) EncryptedVolumeStats(ctx context.Context, in *pb.EncryptedVolumeStatsRequest) (*pb.EncryptedVolumeStatsResponse, error) {
+func (s *Server) EncryptedVolumeStats(_ context.Context, in *pb.EncryptedVolumeStatsRequest) (*pb.EncryptedVolumeStatsResponse, error) {
 	log.Printf("EncryptedVolumeStats: Received from client: %v", in)
 	params := models.BdevGetIostatParams{
 		Name: in.EncryptedVolumeId.Value,

--- a/pkg/server/jsonrpc_test.go
+++ b/pkg/server/jsonrpc_test.go
@@ -64,6 +64,6 @@ func TestSpdk_NewSpdkJSONRPC(t *testing.T) {
 	}
 }
 
-func TestSpdk_Call(t *testing.T) {
+func TestSpdk_Call(_ *testing.T) {
 
 }


### PR DESCRIPTION
Due to golangci update to 1.52.0 version where unused arguments are checked, all unused variables should be replaced with `_` to pass the check