### PR TITLE
Improve qmp monitor in KVM server

### DIFF
--- a/pkg/kvm/monitor.go
+++ b/pkg/kvm/monitor.go
@@ -137,36 +137,24 @@ func (m *monitor) waitForEvent(event string, dataTag string) error {
 		return fmt.Errorf("couldn't get event channel: %v", err)
 	}
 
-	waitChan := make(chan bool, 1)
-	go func() {
-		timeoutTimer := time.NewTimer(m.timeout)
-		for {
-			select {
-			case e := <-stream:
-				log.Println("qemu event:", e)
-				if !strings.Contains(e.Event, event) {
-					continue
-				}
-
-				if dataTag != "" && !m.containsTag(e.Data, dataTag) {
-					continue
-				}
-				waitChan <- true
-				return
-			case <-timeoutTimer.C:
-				log.Println("Event timeout:", event, ",", dataTag)
-				return
-			}
-		}
-	}()
-
 	timeoutTimer := time.NewTimer(m.timeout)
-	select {
-	case <-waitChan:
-		log.Println("Event:", event, "found")
-		return nil
-	case <-timeoutTimer.C:
-		return fmt.Errorf("qemu event not found: %v", event)
+	for {
+		select {
+		case e := <-stream:
+			log.Println("qemu event:", e)
+			if !strings.Contains(e.Event, event) {
+				continue
+			}
+
+			if dataTag != "" && !m.containsTag(e.Data, dataTag) {
+				continue
+			}
+			log.Println("Event:", event, "found")
+			return nil
+		case <-timeoutTimer.C:
+			log.Println("Event timeout:", event, ",", dataTag)
+			return fmt.Errorf("qemu event not found: %v", event)
+		}
 	}
 }
 

--- a/pkg/kvm/nvme.go
+++ b/pkg/kvm/nvme.go
@@ -67,7 +67,7 @@ func (s *Server) CreateNVMeController(ctx context.Context, in *pb.CreateNVMeCont
 		return out, err
 	}
 
-	mon, monErr := newMonitor(s.qmpAddress, s.protocol, s.timeout)
+	mon, monErr := newMonitor(s.qmpAddress, s.protocol, s.timeout, s.pollDevicePresenceStep)
 	if monErr != nil {
 		log.Println("Couldn't create QEMU monitor")
 		_, _ = s.Server.DeleteNVMeController(context.Background(), &pb.DeleteNVMeControllerRequest{Name: id})
@@ -87,7 +87,7 @@ func (s *Server) CreateNVMeController(ctx context.Context, in *pb.CreateNVMeCont
 
 // DeleteNVMeController deletes an NVMe controller device and detaches it from QEMU instance
 func (s *Server) DeleteNVMeController(ctx context.Context, in *pb.DeleteNVMeControllerRequest) (*emptypb.Empty, error) {
-	mon, monErr := newMonitor(s.qmpAddress, s.protocol, s.timeout)
+	mon, monErr := newMonitor(s.qmpAddress, s.protocol, s.timeout, s.pollDevicePresenceStep)
 	if monErr != nil {
 		log.Println("Couldn't create QEMU monitor")
 		return nil, errMonitorCreation

--- a/pkg/kvm/nvme_test.go
+++ b/pkg/kvm/nvme_test.go
@@ -124,6 +124,7 @@ func TestCreateNvmeController(t *testing.T) {
 	tests := map[string]struct {
 		expectAddNvmeController      bool
 		expectAddNvmeControllerError bool
+		expectQueryPci               bool
 
 		jsonRPC                       server.JSONRPC
 		nonDefaultQmpAddress          string
@@ -135,6 +136,7 @@ func TestCreateNvmeController(t *testing.T) {
 	}{
 		"valid NVMe controller creation": {
 			expectAddNvmeController:       true,
+			expectQueryPci:                true,
 			jsonRPC:                       alwaysSuccessfulJSONRPC,
 			ctrlrDirExistsBeforeOperation: false,
 			ctrlrDirExistsAfterOperation:  true,
@@ -192,6 +194,9 @@ func TestCreateNvmeController(t *testing.T) {
 			if test.expectAddNvmeControllerError {
 				qmpServer.ExpectAddNvmeController(testNvmeControllerID, qmpServer.testDir).WithErrorResponse()
 			}
+			if test.expectQueryPci {
+				qmpServer.ExpectQueryPci(testNvmeControllerID)
+			}
 
 			out, err := kvmServer.CreateNVMeController(context.Background(), testCreateNvmeControllerRequest)
 			if !errors.Is(err, test.expectError) {
@@ -217,6 +222,7 @@ func TestDeleteNvmeController(t *testing.T) {
 	tests := map[string]struct {
 		expectDeleteNvmeController      bool
 		expectDeleteNvmeControllerError bool
+		expectQueryPci                  bool
 
 		jsonRPC              server.JSONRPC
 		nonDefaultQmpAddress string
@@ -228,6 +234,7 @@ func TestDeleteNvmeController(t *testing.T) {
 	}{
 		"valid NVMe controller deletion": {
 			expectDeleteNvmeController:    true,
+			expectQueryPci:                true,
 			jsonRPC:                       alwaysSuccessfulJSONRPC,
 			ctrlrDirExistsBeforeOperation: true,
 			ctrlrDirExistsAfterOperation:  false,
@@ -244,6 +251,7 @@ func TestDeleteNvmeController(t *testing.T) {
 		},
 		"spdk failed to delete NVMe controller": {
 			expectDeleteNvmeController:    true,
+			expectQueryPci:                true,
 			jsonRPC:                       alwaysFailingJSONRPC,
 			ctrlrDirExistsBeforeOperation: true,
 			ctrlrDirExistsAfterOperation:  false,
@@ -260,6 +268,7 @@ func TestDeleteNvmeController(t *testing.T) {
 		},
 		"ctrlr dir is not empty after SPDK call": {
 			expectDeleteNvmeController:    true,
+			expectQueryPci:                true,
 			jsonRPC:                       alwaysSuccessfulJSONRPC,
 			ctrlrDirExistsBeforeOperation: true,
 			ctrlrDirExistsAfterOperation:  true,
@@ -268,6 +277,7 @@ func TestDeleteNvmeController(t *testing.T) {
 		},
 		"ctrlr dir does not exist": {
 			expectDeleteNvmeController:    true,
+			expectQueryPci:                true,
 			jsonRPC:                       alwaysSuccessfulJSONRPC,
 			ctrlrDirExistsBeforeOperation: false,
 			ctrlrDirExistsAfterOperation:  false,
@@ -314,6 +324,9 @@ func TestDeleteNvmeController(t *testing.T) {
 			}
 			if test.expectDeleteNvmeControllerError {
 				qmpServer.ExpectDeleteNvmeController(testNvmeControllerID).WithErrorResponse()
+			}
+			if test.expectQueryPci {
+				qmpServer.ExpectQueryPci("")
 			}
 
 			_, err := kvmServer.DeleteNVMeController(context.Background(), testDeleteNvmeControllerRequest)


### PR DESCRIPTION
* Simplify `waitForEvent` method in monitor
* Wait for `DEVICE_DELETED` event with device:<name> pair
* Check for device presence for virtio-blk creation and NVMe controller creation/deletion (with test update)