### PR TITLE
Use socket path by value for JSONRPC.

### DIFF
--- a/pkg/server/jsonrpc.go
+++ b/pkg/server/jsonrpc.go
@@ -33,7 +33,7 @@ type JSONRPC interface {
 
 type spdkJSONRPC struct {
 	transport string
-	socket    *string
+	socket    string
 	id        uint64
 }
 
@@ -51,7 +51,7 @@ func NewSpdkJSONRPC(socketPath string) JSONRPC {
 	log.Printf("Connection to SPDK will be via: %s detected from %s", protocol, socketPath)
 	return &spdkJSONRPC{
 		transport: protocol,
-		socket:    &socketPath,
+		socket:    socketPath,
 		id:        0,
 	}
 }
@@ -96,7 +96,7 @@ func (r *spdkJSONRPC) Call(method string, args, result interface{}) error {
 
 func (r *spdkJSONRPC) communicate(buf []byte) (io.Reader, error) {
 	// connect
-	conn, err := net.Dial(r.transport, *r.socket)
+	conn, err := net.Dial(r.transport, r.socket)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/server/jsonrpc_test.go
+++ b/pkg/server/jsonrpc_test.go
@@ -54,7 +54,7 @@ func TestSpdk_NewSpdkJSONRPC(t *testing.T) {
 			before := NewSpdkJSONRPC(tt.address)
 			after := &spdkJSONRPC{
 				transport: tt.transport,
-				socket:    &tt.address,
+				socket:    tt.address,
 				id:        0,
 			}
 			if !reflect.DeepEqual(before, after) {

--- a/pkg/server/utils.go
+++ b/pkg/server/utils.go
@@ -56,10 +56,10 @@ func GenerateSocketName(testType string) string {
 
 func startSpdkMockupServerOnUnixSocket(rpc *spdkJSONRPC) net.Listener {
 	// start SPDK mockup Server
-	if err := os.RemoveAll(*rpc.socket); err != nil {
+	if err := os.RemoveAll(rpc.socket); err != nil {
 		log.Fatal(err)
 	}
-	ln, err := net.Listen("unix", *rpc.socket)
+	ln, err := net.Listen("unix", rpc.socket)
 	if err != nil {
 		log.Fatal("listen error:", err)
 	}


### PR DESCRIPTION
Use of a pointer to a socket path was used when that path was a global variable. Cleaning up this leftover.