### PR TITLE
List: add pagination support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/digitalocean/go-qemu v0.0.0-20221209210016-f035778c97f7
+	github.com/google/uuid v1.3.0
 	github.com/opiproject/opi-api v0.0.0-20230404182329-b6f178ec8cfa
 	github.com/ulule/deepcopier v0.0.0-20200430083143-45decc6639b6
 	google.golang.org/grpc v1.54.0

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/opiproject/opi-api v0.0.0-20230111150933-e4b3480e8ee9 h1:Y/0Ku5yIfnLEnLa9jzYCK/7l85CHQVefs0PnaXFX+v0=
 github.com/opiproject/opi-api v0.0.0-20230111150933-e4b3480e8ee9/go.mod h1:92pv4ulvvPMuxCJ9ND3aYbmBfEMLx0VCjpkiR7ZTqPY=
 github.com/opiproject/opi-api v0.0.0-20230123165122-10e47bafd42b h1:Ho6qkBoU1vfqERZbih+Hmn7Y1lsx14YtOiqMl4lzdF4=

--- a/pkg/backend/aio.go
+++ b/pkg/backend/aio.go
@@ -144,7 +144,8 @@ func (s *Server) ListAioControllers(_ context.Context, in *pb.ListAioControllers
 	}
 	offset := 0
 	if in.PageToken != "" {
-		offset, ok := s.Pagination[in.PageToken]
+		var ok bool
+		offset, ok = s.Pagination[in.PageToken]
 		if !ok {
 			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
 			log.Printf("error: %v", err)

--- a/pkg/backend/aio.go
+++ b/pkg/backend/aio.go
@@ -9,11 +9,11 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math"
 
 	pc "github.com/opiproject/opi-api/common/v1/gen/go"
 	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
 	"github.com/opiproject/opi-spdk-bridge/pkg/models"
+	"github.com/opiproject/opi-spdk-bridge/pkg/server"
 
 	"github.com/google/uuid"
 	"github.com/ulule/deepcopier"
@@ -138,25 +138,10 @@ func (s *Server) UpdateAioController(_ context.Context, in *pb.UpdateAioControll
 // ListAioControllers lists Aio controllers
 func (s *Server) ListAioControllers(_ context.Context, in *pb.ListAioControllersRequest) (*pb.ListAioControllersResponse, error) {
 	log.Printf("ListAioControllers: Received from client: %v", in)
-	if in.PageSize < 0 {
-		err := status.Error(codes.InvalidArgument, "negative PageSize is not allowed")
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	size := 50
-	if in.PageSize > 0 {
-		size = int(math.Min(float64(in.PageSize), 250))
-	}
-	offset := 0
-	if in.PageToken != "" {
-		var ok bool
-		offset, ok = s.Pagination[in.PageToken]
-		if !ok {
-			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
-			log.Printf("error: %v", err)
-			return nil, err
-		}
-		log.Printf("Found offset %d from pagination token: %s", offset, in.PageToken)
+	size, offset, perr := server.ExtractPagination(in.PageSize, in.PageToken, s.Pagination)
+	if perr != nil {
+		log.Printf("error: %v", perr)
+		return nil, perr
 	}
 	var result []models.BdevGetBdevsResult
 	err := s.rpc.Call("bdev_get_bdevs", nil, &result)

--- a/pkg/backend/aio.go
+++ b/pkg/backend/aio.go
@@ -150,10 +150,10 @@ func (s *Server) ListAioControllers(_ context.Context, in *pb.ListAioControllers
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
-	var token string
-	if size < len(result) {
-		log.Printf("Limiting result to %d:%d", offset, size)
-		result = result[offset:size]
+	token := ""
+	log.Printf("Limiting result len(%d) to [%d:%d]", len(result), offset, size)
+	result, hasMoreElements := server.LimitPagination(result, offset, size)
+	if hasMoreElements {
 		token = uuid.New().String()
 		s.Pagination[token] = offset + size
 	}

--- a/pkg/backend/aio.go
+++ b/pkg/backend/aio.go
@@ -142,6 +142,10 @@ func (s *Server) ListAioControllers(_ context.Context, in *pb.ListAioControllers
 		log.Printf("error: %v", err)
 		return nil, err
 	}
+	size := 50
+	if in.PageSize > 0 {
+		size = int(in.PageSize)
+	}
 	offset := 0
 	if in.PageToken != "" {
 		var ok bool
@@ -161,11 +165,11 @@ func (s *Server) ListAioControllers(_ context.Context, in *pb.ListAioControllers
 	}
 	log.Printf("Received from SPDK: %v", result)
 	var token string
-	if in.PageSize > 0 && int(in.PageSize) < len(result) {
-		log.Printf("Limiting result to %d:%d", offset, in.PageSize)
-		result = result[offset:in.PageSize]
+	if size < len(result) {
+		log.Printf("Limiting result to %d:%d", offset, size)
+		result = result[offset:size]
 		token = uuid.New().String()
-		s.Pagination[token] = offset + int(in.PageSize)
+		s.Pagination[token] = offset + size
 	}
 	Blobarray := make([]*pb.AioController, len(result))
 	for i := range result {

--- a/pkg/backend/aio.go
+++ b/pkg/backend/aio.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 
 	pc "github.com/opiproject/opi-api/common/v1/gen/go"
 	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
@@ -144,7 +145,7 @@ func (s *Server) ListAioControllers(_ context.Context, in *pb.ListAioControllers
 	}
 	size := 50
 	if in.PageSize > 0 {
-		size = int(in.PageSize)
+		size = int(math.Min(float64(in.PageSize), 250))
 	}
 	offset := 0
 	if in.PageToken != "" {

--- a/pkg/backend/aio.go
+++ b/pkg/backend/aio.go
@@ -142,6 +142,16 @@ func (s *Server) ListAioControllers(_ context.Context, in *pb.ListAioControllers
 		log.Printf("error: %v", err)
 		return nil, err
 	}
+	offset := 0
+	if in.PageToken != "" {
+		offset, ok := s.Pagination[in.PageToken]
+		if !ok {
+			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
+			log.Printf("error: %v", err)
+			return nil, err
+		}
+		log.Printf("Found offset %d from pagination token: %s", offset, in.PageToken)
+	}
 	var result []models.BdevGetBdevsResult
 	err := s.rpc.Call("bdev_get_bdevs", nil, &result)
 	if err != nil {
@@ -151,10 +161,10 @@ func (s *Server) ListAioControllers(_ context.Context, in *pb.ListAioControllers
 	log.Printf("Received from SPDK: %v", result)
 	var token string
 	if in.PageSize > 0 && int(in.PageSize) < len(result) {
-		log.Printf("Limiting result to: %d", in.PageSize)
-		result = result[:in.PageSize]
+		log.Printf("Limiting result to %d:%d", offset, in.PageSize)
+		result = result[offset:in.PageSize]
 		token = uuid.New().String()
-		s.Pagination[token] = int(in.PageSize)
+		s.Pagination[token] = offset + int(in.PageSize)
 	}
 	Blobarray := make([]*pb.AioController, len(result))
 	for i := range result {

--- a/pkg/backend/aio_test.go
+++ b/pkg/backend/aio_test.go
@@ -362,6 +362,10 @@ func TestBackEnd_ListAioControllers(t *testing.T) {
 				if !reflect.DeepEqual(response.AioControllers, tt.out) {
 					t.Error("response: expected", tt.out, "received", response.AioControllers)
 				}
+				// Empty NextPageToken indicates end of results list
+				if tt.size != 1 && response.NextPageToken != "" {
+					t.Error("response: expected", tt, "received", response)
+				}
 			}
 
 			if err != nil {

--- a/pkg/backend/aio_test.go
+++ b/pkg/backend/aio_test.go
@@ -386,7 +386,7 @@ func TestBackEnd_ListAioControllers(t *testing.T) {
 				}
 				// Empty NextPageToken indicates end of results list
 				if tt.size != 1 && response.NextPageToken != "" {
-					t.Error("response: expected", tt, "received", response)
+					t.Error("Expected end of results, receieved non-empty next page token", response.NextPageToken)
 				}
 			}
 

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -26,8 +26,9 @@ type Server struct {
 	pb.UnimplementedNullDebugServiceServer
 	pb.UnimplementedAioControllerServiceServer
 
-	rpc     server.JSONRPC
-	Volumes VolumeParameters
+	rpc        server.JSONRPC
+	Volumes    VolumeParameters
+	Pagination map[string]int
 }
 
 // NewServer creates initialized instance of BackEnd server communicating
@@ -40,5 +41,6 @@ func NewServer(jsonRPC server.JSONRPC) *Server {
 			NullVolumes: make(map[string]*pb.NullDebug),
 			NvmeVolumes: make(map[string]*pb.NVMfRemoteController),
 		},
+		Pagination: make(map[string]int),
 	}
 }

--- a/pkg/backend/null.go
+++ b/pkg/backend/null.go
@@ -142,6 +142,10 @@ func (s *Server) ListNullDebugs(_ context.Context, in *pb.ListNullDebugsRequest)
 		log.Printf("error: %v", err)
 		return nil, err
 	}
+	size := 50
+	if in.PageSize > 0 {
+		size = int(in.PageSize)
+	}
 	offset := 0
 	if in.PageToken != "" {
 		var ok bool
@@ -161,11 +165,11 @@ func (s *Server) ListNullDebugs(_ context.Context, in *pb.ListNullDebugsRequest)
 	}
 	log.Printf("Received from SPDK: %v", result)
 	var token string
-	if in.PageSize > 0 && int(in.PageSize) < len(result) {
-		log.Printf("Limiting result to %d:%d", offset, in.PageSize)
-		result = result[offset:in.PageSize]
+	if size < len(result) {
+		log.Printf("Limiting result to %d:%d", offset, size)
+		result = result[offset:size]
 		token = uuid.New().String()
-		s.Pagination[token] = offset + int(in.PageSize)
+		s.Pagination[token] = offset + size
 	}
 	Blobarray := make([]*pb.NullDebug, len(result))
 	for i := range result {

--- a/pkg/backend/null.go
+++ b/pkg/backend/null.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 
 	pc "github.com/opiproject/opi-api/common/v1/gen/go"
 	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
@@ -144,7 +145,7 @@ func (s *Server) ListNullDebugs(_ context.Context, in *pb.ListNullDebugsRequest)
 	}
 	size := 50
 	if in.PageSize > 0 {
-		size = int(in.PageSize)
+		size = int(math.Min(float64(in.PageSize), 250))
 	}
 	offset := 0
 	if in.PageToken != "" {

--- a/pkg/backend/null.go
+++ b/pkg/backend/null.go
@@ -144,7 +144,8 @@ func (s *Server) ListNullDebugs(_ context.Context, in *pb.ListNullDebugsRequest)
 	}
 	offset := 0
 	if in.PageToken != "" {
-		offset, ok := s.Pagination[in.PageToken]
+		var ok bool
+		offset, ok = s.Pagination[in.PageToken]
 		if !ok {
 			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
 			log.Printf("error: %v", err)

--- a/pkg/backend/null.go
+++ b/pkg/backend/null.go
@@ -142,6 +142,16 @@ func (s *Server) ListNullDebugs(_ context.Context, in *pb.ListNullDebugsRequest)
 		log.Printf("error: %v", err)
 		return nil, err
 	}
+	offset := 0
+	if in.PageToken != "" {
+		offset, ok := s.Pagination[in.PageToken]
+		if !ok {
+			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
+			log.Printf("error: %v", err)
+			return nil, err
+		}
+		log.Printf("Found offset %d from pagination token: %s", offset, in.PageToken)
+	}
 	var result []models.BdevGetBdevsResult
 	err := s.rpc.Call("bdev_get_bdevs", nil, &result)
 	if err != nil {
@@ -151,10 +161,10 @@ func (s *Server) ListNullDebugs(_ context.Context, in *pb.ListNullDebugsRequest)
 	log.Printf("Received from SPDK: %v", result)
 	var token string
 	if in.PageSize > 0 && int(in.PageSize) < len(result) {
-		log.Printf("Limiting result to: %d", in.PageSize)
-		result = result[:in.PageSize]
+		log.Printf("Limiting result to %d:%d", offset, in.PageSize)
+		result = result[offset:in.PageSize]
 		token = uuid.New().String()
-		s.Pagination[token] = int(in.PageSize)
+		s.Pagination[token] = offset + int(in.PageSize)
 	}
 	Blobarray := make([]*pb.NullDebug, len(result))
 	for i := range result {

--- a/pkg/backend/null.go
+++ b/pkg/backend/null.go
@@ -9,11 +9,11 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math"
 
 	pc "github.com/opiproject/opi-api/common/v1/gen/go"
 	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
 	"github.com/opiproject/opi-spdk-bridge/pkg/models"
+	"github.com/opiproject/opi-spdk-bridge/pkg/server"
 
 	"github.com/google/uuid"
 	"github.com/ulule/deepcopier"
@@ -138,25 +138,10 @@ func (s *Server) UpdateNullDebug(_ context.Context, in *pb.UpdateNullDebugReques
 // ListNullDebugs lists Null Debug instances
 func (s *Server) ListNullDebugs(_ context.Context, in *pb.ListNullDebugsRequest) (*pb.ListNullDebugsResponse, error) {
 	log.Printf("ListNullDebugs: Received from client: %v", in)
-	if in.PageSize < 0 {
-		err := status.Error(codes.InvalidArgument, "negative PageSize is not allowed")
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	size := 50
-	if in.PageSize > 0 {
-		size = int(math.Min(float64(in.PageSize), 250))
-	}
-	offset := 0
-	if in.PageToken != "" {
-		var ok bool
-		offset, ok = s.Pagination[in.PageToken]
-		if !ok {
-			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
-			log.Printf("error: %v", err)
-			return nil, err
-		}
-		log.Printf("Found offset %d from pagination token: %s", offset, in.PageToken)
+	size, offset, perr := server.ExtractPagination(in.PageSize, in.PageToken, s.Pagination)
+	if perr != nil {
+		log.Printf("error: %v", perr)
+		return nil, perr
 	}
 	var result []models.BdevGetBdevsResult
 	err := s.rpc.Call("bdev_get_bdevs", nil, &result)

--- a/pkg/backend/null.go
+++ b/pkg/backend/null.go
@@ -150,10 +150,10 @@ func (s *Server) ListNullDebugs(_ context.Context, in *pb.ListNullDebugsRequest)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
-	var token string
-	if size < len(result) {
-		log.Printf("Limiting result to %d:%d", offset, size)
-		result = result[offset:size]
+	token := ""
+	log.Printf("Limiting result len(%d) to [%d:%d]", len(result), offset, size)
+	result, hasMoreElements := server.LimitPagination(result, offset, size)
+	if hasMoreElements {
 		token = uuid.New().String()
 		s.Pagination[token] = offset + size
 	}

--- a/pkg/backend/null_test.go
+++ b/pkg/backend/null_test.go
@@ -390,7 +390,7 @@ func TestBackEnd_ListNullDebugs(t *testing.T) {
 				}
 				// Empty NextPageToken indicates end of results list
 				if tt.size != 1 && response.NextPageToken != "" {
-					t.Error("response: expected", tt, "received", response)
+					t.Error("Expected end of results, receieved non-empty next page token", response.NextPageToken)
 				}
 			}
 

--- a/pkg/backend/null_test.go
+++ b/pkg/backend/null_test.go
@@ -366,6 +366,10 @@ func TestBackEnd_ListNullDebugs(t *testing.T) {
 				if !reflect.DeepEqual(response.NullDebugs, tt.out) {
 					t.Error("response: expected", tt.out, "received", response.NullDebugs)
 				}
+				// Empty NextPageToken indicates end of results list
+				if tt.size != 1 && response.NextPageToken != "" {
+					t.Error("response: expected", tt, "received", response)
+				}
 			}
 
 			if err != nil {

--- a/pkg/backend/nvme.go
+++ b/pkg/backend/nvme.go
@@ -104,6 +104,16 @@ func (s *Server) ListNVMfRemoteControllers(_ context.Context, in *pb.ListNVMfRem
 		log.Printf("error: %v", err)
 		return nil, err
 	}
+	offset := 0
+	if in.PageToken != "" {
+		offset, ok := s.Pagination[in.PageToken]
+		if !ok {
+			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
+			log.Printf("error: %v", err)
+			return nil, err
+		}
+		log.Printf("Found offset %d from pagination token: %s", offset, in.PageToken)
+	}
 	var result []models.BdevNvmeGetControllerResult
 	err := s.rpc.Call("bdev_nvme_get_controllers", nil, &result)
 	if err != nil {
@@ -113,10 +123,10 @@ func (s *Server) ListNVMfRemoteControllers(_ context.Context, in *pb.ListNVMfRem
 	log.Printf("Received from SPDK: %v", result)
 	var token string
 	if in.PageSize > 0 && int(in.PageSize) < len(result) {
-		log.Printf("Limiting result to: %d", in.PageSize)
-		result = result[:in.PageSize]
+		log.Printf("Limiting result to %d:%d", offset, in.PageSize)
+		result = result[offset:in.PageSize]
 		token = uuid.New().String()
-		s.Pagination[token] = int(in.PageSize)
+		s.Pagination[token] = offset + int(in.PageSize)
 	}
 	Blobarray := make([]*pb.NVMfRemoteController, len(result))
 	for i := range result {

--- a/pkg/backend/nvme.go
+++ b/pkg/backend/nvme.go
@@ -104,6 +104,10 @@ func (s *Server) ListNVMfRemoteControllers(_ context.Context, in *pb.ListNVMfRem
 		log.Printf("error: %v", err)
 		return nil, err
 	}
+	size := 50
+	if in.PageSize > 0 {
+		size = int(in.PageSize)
+	}
 	offset := 0
 	if in.PageToken != "" {
 		var ok bool
@@ -123,11 +127,11 @@ func (s *Server) ListNVMfRemoteControllers(_ context.Context, in *pb.ListNVMfRem
 	}
 	log.Printf("Received from SPDK: %v", result)
 	var token string
-	if in.PageSize > 0 && int(in.PageSize) < len(result) {
-		log.Printf("Limiting result to %d:%d", offset, in.PageSize)
-		result = result[offset:in.PageSize]
+	if size < len(result) {
+		log.Printf("Limiting result to %d:%d", offset, size)
+		result = result[offset:size]
 		token = uuid.New().String()
-		s.Pagination[token] = offset + int(in.PageSize)
+		s.Pagination[token] = offset + size
 	}
 	Blobarray := make([]*pb.NVMfRemoteController, len(result))
 	for i := range result {

--- a/pkg/backend/nvme.go
+++ b/pkg/backend/nvme.go
@@ -112,10 +112,10 @@ func (s *Server) ListNVMfRemoteControllers(_ context.Context, in *pb.ListNVMfRem
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
-	var token string
-	if size < len(result) {
-		log.Printf("Limiting result to %d:%d", offset, size)
-		result = result[offset:size]
+	token := ""
+	log.Printf("Limiting result len(%d) to [%d:%d]", len(result), offset, size)
+	result, hasMoreElements := server.LimitPagination(result, offset, size)
+	if hasMoreElements {
 		token = uuid.New().String()
 		s.Pagination[token] = offset + size
 	}

--- a/pkg/backend/nvme.go
+++ b/pkg/backend/nvme.go
@@ -15,6 +15,7 @@ import (
 	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
 	"github.com/opiproject/opi-spdk-bridge/pkg/models"
 
+	"github.com/google/uuid"
 	"github.com/ulule/deepcopier"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -110,9 +111,12 @@ func (s *Server) ListNVMfRemoteControllers(_ context.Context, in *pb.ListNVMfRem
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
+	var token string
 	if in.PageSize > 0 && int(in.PageSize) < len(result) {
 		log.Printf("Limiting result to: %d", in.PageSize)
 		result = result[:in.PageSize]
+		token = uuid.New().String()
+		s.Pagination[token] = int(in.PageSize)
 	}
 	Blobarray := make([]*pb.NVMfRemoteController, len(result))
 	for i := range result {
@@ -128,7 +132,7 @@ func (s *Server) ListNVMfRemoteControllers(_ context.Context, in *pb.ListNVMfRem
 			Trsvcid: port,
 		}
 	}
-	return &pb.ListNVMfRemoteControllersResponse{NvMfRemoteControllers: Blobarray}, nil
+	return &pb.ListNVMfRemoteControllersResponse{NvMfRemoteControllers: Blobarray, NextPageToken: token}, nil
 }
 
 // GetNVMfRemoteController gets an NVMf remote controller

--- a/pkg/backend/nvme.go
+++ b/pkg/backend/nvme.go
@@ -106,7 +106,8 @@ func (s *Server) ListNVMfRemoteControllers(_ context.Context, in *pb.ListNVMfRem
 	}
 	offset := 0
 	if in.PageToken != "" {
-		offset, ok := s.Pagination[in.PageToken]
+		var ok bool
+		offset, ok = s.Pagination[in.PageToken]
 		if !ok {
 			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
 			log.Printf("error: %v", err)

--- a/pkg/backend/nvme.go
+++ b/pkg/backend/nvme.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"strconv"
 	"strings"
 
@@ -106,7 +107,7 @@ func (s *Server) ListNVMfRemoteControllers(_ context.Context, in *pb.ListNVMfRem
 	}
 	size := 50
 	if in.PageSize > 0 {
-		size = int(in.PageSize)
+		size = int(math.Min(float64(in.PageSize), 250))
 	}
 	offset := 0
 	if in.PageToken != "" {

--- a/pkg/backend/nvme_test.go
+++ b/pkg/backend/nvme_test.go
@@ -339,7 +339,7 @@ func TestBackEnd_ListNVMfRemoteControllers(t *testing.T) {
 				}
 				// Empty NextPageToken indicates end of results list
 				if tt.size != 1 && response.NextPageToken != "" {
-					t.Error("response: expected", tt, "received", response)
+					t.Error("Expected end of results, receieved non-empty next page token", response.NextPageToken)
 				}
 			}
 

--- a/pkg/backend/nvme_test.go
+++ b/pkg/backend/nvme_test.go
@@ -315,6 +315,10 @@ func TestBackEnd_ListNVMfRemoteControllers(t *testing.T) {
 				if !reflect.DeepEqual(response.NvMfRemoteControllers, tt.out) {
 					t.Error("response: expected", tt.out, "received", response.NvMfRemoteControllers)
 				}
+				// Empty NextPageToken indicates end of results list
+				if tt.size != 1 && response.NextPageToken != "" {
+					t.Error("response: expected", tt, "received", response)
+				}
 			}
 
 			if err != nil {

--- a/pkg/frontend/blk.go
+++ b/pkg/frontend/blk.go
@@ -103,7 +103,8 @@ func (s *Server) ListVirtioBlks(_ context.Context, in *pb.ListVirtioBlksRequest)
 	}
 	offset := 0
 	if in.PageToken != "" {
-		offset, ok := s.Pagination[in.PageToken]
+		var ok bool
+		offset, ok = s.Pagination[in.PageToken]
 		if !ok {
 			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
 			log.Printf("error: %v", err)

--- a/pkg/frontend/blk.go
+++ b/pkg/frontend/blk.go
@@ -101,6 +101,16 @@ func (s *Server) ListVirtioBlks(_ context.Context, in *pb.ListVirtioBlksRequest)
 		log.Printf("error: %v", err)
 		return nil, err
 	}
+	offset := 0
+	if in.PageToken != "" {
+		offset, ok := s.Pagination[in.PageToken]
+		if !ok {
+			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
+			log.Printf("error: %v", err)
+			return nil, err
+		}
+		log.Printf("Found offset %d from pagination token: %s", offset, in.PageToken)
+	}
 	var result []models.VhostGetControllersResult
 	err := s.rpc.Call("vhost_get_controllers", nil, &result)
 	if err != nil {
@@ -110,10 +120,10 @@ func (s *Server) ListVirtioBlks(_ context.Context, in *pb.ListVirtioBlksRequest)
 	log.Printf("Received from SPDK: %v", result)
 	var token string
 	if in.PageSize > 0 && int(in.PageSize) < len(result) {
-		log.Printf("Limiting result to: %d", in.PageSize)
-		result = result[:in.PageSize]
+		log.Printf("Limiting result to %d:%d", offset, in.PageSize)
+		result = result[offset:in.PageSize]
 		token = uuid.New().String()
-		s.Pagination[token] = int(in.PageSize)
+		s.Pagination[token] = offset + int(in.PageSize)
 	}
 	Blobarray := make([]*pb.VirtioBlk, len(result))
 	for i := range result {

--- a/pkg/frontend/blk.go
+++ b/pkg/frontend/blk.go
@@ -108,10 +108,10 @@ func (s *Server) ListVirtioBlks(_ context.Context, in *pb.ListVirtioBlksRequest)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
-	var token string
-	if size < len(result) {
-		log.Printf("Limiting result to %d:%d", offset, size)
-		result = result[offset:size]
+	token := ""
+	log.Printf("Limiting result len(%d) to [%d:%d]", len(result), offset, size)
+	result, hasMoreElements := server.LimitPagination(result, offset, size)
+	if hasMoreElements {
 		token = uuid.New().String()
 		s.Pagination[token] = offset + size
 	}

--- a/pkg/frontend/blk.go
+++ b/pkg/frontend/blk.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 
 	"github.com/google/uuid"
 	pc "github.com/opiproject/opi-api/common/v1/gen/go"
@@ -103,7 +104,7 @@ func (s *Server) ListVirtioBlks(_ context.Context, in *pb.ListVirtioBlksRequest)
 	}
 	size := 50
 	if in.PageSize > 0 {
-		size = int(in.PageSize)
+		size = int(math.Min(float64(in.PageSize), 250))
 	}
 	offset := 0
 	if in.PageToken != "" {

--- a/pkg/frontend/blk.go
+++ b/pkg/frontend/blk.go
@@ -101,6 +101,10 @@ func (s *Server) ListVirtioBlks(_ context.Context, in *pb.ListVirtioBlksRequest)
 		log.Printf("error: %v", err)
 		return nil, err
 	}
+	size := 50
+	if in.PageSize > 0 {
+		size = int(in.PageSize)
+	}
 	offset := 0
 	if in.PageToken != "" {
 		var ok bool
@@ -120,11 +124,11 @@ func (s *Server) ListVirtioBlks(_ context.Context, in *pb.ListVirtioBlksRequest)
 	}
 	log.Printf("Received from SPDK: %v", result)
 	var token string
-	if in.PageSize > 0 && int(in.PageSize) < len(result) {
-		log.Printf("Limiting result to %d:%d", offset, in.PageSize)
-		result = result[offset:in.PageSize]
+	if size < len(result) {
+		log.Printf("Limiting result to %d:%d", offset, size)
+		result = result[offset:size]
 		token = uuid.New().String()
-		s.Pagination[token] = offset + int(in.PageSize)
+		s.Pagination[token] = offset + size
 	}
 	Blobarray := make([]*pb.VirtioBlk, len(result))
 	for i := range result {

--- a/pkg/frontend/blk_test.go
+++ b/pkg/frontend/blk_test.go
@@ -292,7 +292,7 @@ func TestFrontEnd_ListVirtioBlks(t *testing.T) {
 				}
 				// Empty NextPageToken indicates end of results list
 				if tt.size != 1 && response.NextPageToken != "" {
-					t.Error("response: expected", tt, "received", response)
+					t.Error("Expected end of results, receieved non-empty next page token", response.NextPageToken)
 				}
 			}
 

--- a/pkg/frontend/blk_test.go
+++ b/pkg/frontend/blk_test.go
@@ -269,6 +269,10 @@ func TestFrontEnd_ListVirtioBlks(t *testing.T) {
 				if !reflect.DeepEqual(response.VirtioBlks, tt.out) {
 					t.Error("response: expected", tt.out, "received", response.VirtioBlks)
 				}
+				// Empty NextPageToken indicates end of results list
+				if tt.size != 1 && response.NextPageToken != "" {
+					t.Error("response: expected", tt, "received", response)
+				}
 			}
 
 			if err != nil {

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -40,9 +40,10 @@ type Server struct {
 	pb.UnimplementedFrontendVirtioBlkServiceServer
 	pb.UnimplementedFrontendVirtioScsiServiceServer
 
-	rpc  server.JSONRPC
-	Nvme NvmeParameters
-	Virt VirtioParameters
+	rpc        server.JSONRPC
+	Nvme       NvmeParameters
+	Virt       VirtioParameters
+	Pagination map[string]int
 }
 
 // NewServer creates initialized instance of FrontEnd server communicating
@@ -61,6 +62,7 @@ func NewServer(jsonRPC server.JSONRPC) *Server {
 			ScsiCtrls: make(map[string]*pb.VirtioScsiController),
 			ScsiLuns:  make(map[string]*pb.VirtioScsiLun),
 		},
+		Pagination: make(map[string]int),
 	}
 }
 

--- a/pkg/frontend/nvme.go
+++ b/pkg/frontend/nvme.go
@@ -168,7 +168,8 @@ func (s *Server) ListNVMeSubsystems(_ context.Context, in *pb.ListNVMeSubsystems
 	}
 	offset := 0
 	if in.PageToken != "" {
-		offset, ok := s.Pagination[in.PageToken]
+		var ok bool
+		offset, ok = s.Pagination[in.PageToken]
 		if !ok {
 			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
 			log.Printf("error: %v", err)
@@ -475,7 +476,8 @@ func (s *Server) ListNVMeNamespaces(_ context.Context, in *pb.ListNVMeNamespaces
 	}
 	offset := 0
 	if in.PageToken != "" {
-		offset, ok := s.Pagination[in.PageToken]
+		var ok bool
+		offset, ok = s.Pagination[in.PageToken]
 		if !ok {
 			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
 			log.Printf("error: %v", err)

--- a/pkg/frontend/nvme.go
+++ b/pkg/frontend/nvme.go
@@ -166,6 +166,10 @@ func (s *Server) ListNVMeSubsystems(_ context.Context, in *pb.ListNVMeSubsystems
 		log.Printf("error: %v", err)
 		return nil, err
 	}
+	size := 50
+	if in.PageSize > 0 {
+		size = int(in.PageSize)
+	}
 	offset := 0
 	if in.PageToken != "" {
 		var ok bool
@@ -185,11 +189,11 @@ func (s *Server) ListNVMeSubsystems(_ context.Context, in *pb.ListNVMeSubsystems
 	}
 	log.Printf("Received from SPDK: %v", result)
 	var token string
-	if in.PageSize > 0 && int(in.PageSize) < len(result) {
-		log.Printf("Limiting result to %d:%d", offset, in.PageSize)
-		result = result[offset:in.PageSize]
+	if size < len(result) {
+		log.Printf("Limiting result to %d:%d", offset, size)
+		result = result[offset:size]
 		token = uuid.New().String()
-		s.Pagination[token] = offset + int(in.PageSize)
+		s.Pagination[token] = offset + size
 	}
 	Blobarray := make([]*pb.NVMeSubsystem, len(result))
 	for i := range result {
@@ -474,6 +478,10 @@ func (s *Server) ListNVMeNamespaces(_ context.Context, in *pb.ListNVMeNamespaces
 		log.Printf("error: %v", err)
 		return nil, err
 	}
+	size := 50
+	if in.PageSize > 0 {
+		size = int(in.PageSize)
+	}
 	offset := 0
 	if in.PageToken != "" {
 		var ok bool
@@ -507,11 +515,11 @@ func (s *Server) ListNVMeNamespaces(_ context.Context, in *pb.ListNVMeNamespaces
 	for i := range result {
 		rr := &result[i]
 		if rr.Nqn == nqn || nqn == "" {
-			if in.PageSize > 0 && int(in.PageSize) < len(result) {
-				log.Printf("Limiting result to %d:%d", offset, in.PageSize)
-				rr.Namespaces = rr.Namespaces[offset:in.PageSize]
+			if size < len(result) {
+				log.Printf("Limiting result to %d:%d", offset, size)
+				rr.Namespaces = rr.Namespaces[offset:size]
 				token = uuid.New().String()
-				s.Pagination[token] = offset + int(in.PageSize)
+				s.Pagination[token] = offset + size
 			}
 			for j := range rr.Namespaces {
 				r := &rr.Namespaces[j]

--- a/pkg/frontend/nvme.go
+++ b/pkg/frontend/nvme.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"net"
 
 	pc "github.com/opiproject/opi-api/common/v1/gen/go"
@@ -168,7 +169,7 @@ func (s *Server) ListNVMeSubsystems(_ context.Context, in *pb.ListNVMeSubsystems
 	}
 	size := 50
 	if in.PageSize > 0 {
-		size = int(in.PageSize)
+		size = int(math.Min(float64(in.PageSize), 250))
 	}
 	offset := 0
 	if in.PageToken != "" {
@@ -480,7 +481,7 @@ func (s *Server) ListNVMeNamespaces(_ context.Context, in *pb.ListNVMeNamespaces
 	}
 	size := 50
 	if in.PageSize > 0 {
-		size = int(in.PageSize)
+		size = int(math.Min(float64(in.PageSize), 250))
 	}
 	offset := 0
 	if in.PageToken != "" {

--- a/pkg/frontend/nvme_test.go
+++ b/pkg/frontend/nvme_test.go
@@ -378,7 +378,7 @@ func TestFrontEnd_ListNVMeSubsystem(t *testing.T) {
 				}
 				// Empty NextPageToken indicates end of results list
 				if tt.size != 1 && response.NextPageToken != "" {
-					t.Error("response: expected", tt, "received", response)
+					t.Error("Expected end of results, receieved non-empty next page token", response.NextPageToken)
 				}
 			}
 
@@ -1365,7 +1365,7 @@ func TestFrontEnd_ListNVMeNamespaces(t *testing.T) {
 				}
 				// Empty NextPageToken indicates end of results list
 				if tt.size != 1 && response.NextPageToken != "" {
-					t.Error("response: expected", tt, "received", response)
+					t.Error("Expected end of results, receieved non-empty next page token", response.NextPageToken)
 				}
 			}
 

--- a/pkg/frontend/nvme_test.go
+++ b/pkg/frontend/nvme_test.go
@@ -357,6 +357,10 @@ func TestFrontEnd_ListNVMeSubsystem(t *testing.T) {
 				if !reflect.DeepEqual(response.NvMeSubsystems, tt.out) {
 					t.Error("response: expected", tt.out, "received", response.NvMeSubsystems)
 				}
+				// Empty NextPageToken indicates end of results list
+				if tt.size != 1 && response.NextPageToken != "" {
+					t.Error("response: expected", tt, "received", response)
+				}
 			}
 
 			if err != nil {
@@ -1315,6 +1319,10 @@ func TestFrontEnd_ListNVMeNamespaces(t *testing.T) {
 			if response != nil {
 				if !reflect.DeepEqual(response.NvMeNamespaces, tt.out) {
 					t.Error("response: expected", tt.out, "received", response.NvMeNamespaces)
+				}
+				// Empty NextPageToken indicates end of results list
+				if tt.size != 1 && response.NextPageToken != "" {
+					t.Error("response: expected", tt, "received", response)
 				}
 			}
 

--- a/pkg/frontend/scsi.go
+++ b/pkg/frontend/scsi.go
@@ -14,6 +14,7 @@ import (
 	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
 	"github.com/opiproject/opi-spdk-bridge/pkg/models"
 
+	"github.com/google/uuid"
 	"github.com/ulule/deepcopier"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -85,16 +86,19 @@ func (s *Server) ListVirtioScsiControllers(_ context.Context, in *pb.ListVirtioS
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
+	var token string
 	if in.PageSize > 0 && int(in.PageSize) < len(result) {
 		log.Printf("Limiting result to: %d", in.PageSize)
 		result = result[:in.PageSize]
+		token = uuid.New().String()
+		s.Pagination[token] = int(in.PageSize)
 	}
 	Blobarray := make([]*pb.VirtioScsiController, len(result))
 	for i := range result {
 		r := &result[i]
 		Blobarray[i] = &pb.VirtioScsiController{Id: &pc.ObjectKey{Value: r.Ctrlr}}
 	}
-	return &pb.ListVirtioScsiControllersResponse{VirtioScsiControllers: Blobarray}, nil
+	return &pb.ListVirtioScsiControllersResponse{VirtioScsiControllers: Blobarray, NextPageToken: token}, nil
 }
 
 // GetVirtioScsiController gets a Virtio SCSI controller
@@ -190,16 +194,19 @@ func (s *Server) ListVirtioScsiLuns(_ context.Context, in *pb.ListVirtioScsiLuns
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
+	var token string
 	if in.PageSize > 0 && int(in.PageSize) < len(result) {
 		log.Printf("Limiting result to: %d", in.PageSize)
 		result = result[:in.PageSize]
+		token = uuid.New().String()
+		s.Pagination[token] = int(in.PageSize)
 	}
 	Blobarray := make([]*pb.VirtioScsiLun, len(result))
 	for i := range result {
 		r := &result[i]
 		Blobarray[i] = &pb.VirtioScsiLun{VolumeId: &pc.ObjectKey{Value: r.Ctrlr}}
 	}
-	return &pb.ListVirtioScsiLunsResponse{VirtioScsiLuns: Blobarray}, nil
+	return &pb.ListVirtioScsiLunsResponse{VirtioScsiLuns: Blobarray, NextPageToken: token}, nil
 }
 
 // GetVirtioScsiLun gets a Virtio SCSI LUN

--- a/pkg/frontend/scsi.go
+++ b/pkg/frontend/scsi.go
@@ -79,6 +79,10 @@ func (s *Server) ListVirtioScsiControllers(_ context.Context, in *pb.ListVirtioS
 		log.Printf("error: %v", err)
 		return nil, err
 	}
+	size := 50
+	if in.PageSize > 0 {
+		size = int(in.PageSize)
+	}
 	offset := 0
 	if in.PageToken != "" {
 		var ok bool
@@ -98,11 +102,11 @@ func (s *Server) ListVirtioScsiControllers(_ context.Context, in *pb.ListVirtioS
 	}
 	log.Printf("Received from SPDK: %v", result)
 	var token string
-	if in.PageSize > 0 && int(in.PageSize) < len(result) {
-		log.Printf("Limiting result to %d:%d", offset, in.PageSize)
-		result = result[offset:in.PageSize]
+	if size < len(result) {
+		log.Printf("Limiting result to %d:%d", offset, size)
+		result = result[offset:size]
 		token = uuid.New().String()
-		s.Pagination[token] = offset + int(in.PageSize)
+		s.Pagination[token] = offset + size
 	}
 	Blobarray := make([]*pb.VirtioScsiController, len(result))
 	for i := range result {
@@ -198,6 +202,10 @@ func (s *Server) ListVirtioScsiLuns(_ context.Context, in *pb.ListVirtioScsiLuns
 		log.Printf("error: %v", err)
 		return nil, err
 	}
+	size := 50
+	if in.PageSize > 0 {
+		size = int(in.PageSize)
+	}
 	offset := 0
 	if in.PageToken != "" {
 		var ok bool
@@ -217,11 +225,11 @@ func (s *Server) ListVirtioScsiLuns(_ context.Context, in *pb.ListVirtioScsiLuns
 	}
 	log.Printf("Received from SPDK: %v", result)
 	var token string
-	if in.PageSize > 0 && int(in.PageSize) < len(result) {
-		log.Printf("Limiting result to %d:%d", offset, in.PageSize)
-		result = result[offset:in.PageSize]
+	if size < len(result) {
+		log.Printf("Limiting result to %d:%d", offset, size)
+		result = result[offset:size]
 		token = uuid.New().String()
-		s.Pagination[token] = offset + int(in.PageSize)
+		s.Pagination[token] = offset + size
 	}
 	Blobarray := make([]*pb.VirtioScsiLun, len(result))
 	for i := range result {

--- a/pkg/frontend/scsi.go
+++ b/pkg/frontend/scsi.go
@@ -79,6 +79,16 @@ func (s *Server) ListVirtioScsiControllers(_ context.Context, in *pb.ListVirtioS
 		log.Printf("error: %v", err)
 		return nil, err
 	}
+	offset := 0
+	if in.PageToken != "" {
+		offset, ok := s.Pagination[in.PageToken]
+		if !ok {
+			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
+			log.Printf("error: %v", err)
+			return nil, err
+		}
+		log.Printf("Found offset %d from pagination token: %s", offset, in.PageToken)
+	}
 	var result []models.VhostGetControllersResult
 	err := s.rpc.Call("vhost_get_controllers", nil, &result)
 	if err != nil {
@@ -88,10 +98,10 @@ func (s *Server) ListVirtioScsiControllers(_ context.Context, in *pb.ListVirtioS
 	log.Printf("Received from SPDK: %v", result)
 	var token string
 	if in.PageSize > 0 && int(in.PageSize) < len(result) {
-		log.Printf("Limiting result to: %d", in.PageSize)
-		result = result[:in.PageSize]
+		log.Printf("Limiting result to %d:%d", offset, in.PageSize)
+		result = result[offset:in.PageSize]
 		token = uuid.New().String()
-		s.Pagination[token] = int(in.PageSize)
+		s.Pagination[token] = offset + int(in.PageSize)
 	}
 	Blobarray := make([]*pb.VirtioScsiController, len(result))
 	for i := range result {
@@ -187,6 +197,16 @@ func (s *Server) ListVirtioScsiLuns(_ context.Context, in *pb.ListVirtioScsiLuns
 		log.Printf("error: %v", err)
 		return nil, err
 	}
+	offset := 0
+	if in.PageToken != "" {
+		offset, ok := s.Pagination[in.PageToken]
+		if !ok {
+			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
+			log.Printf("error: %v", err)
+			return nil, err
+		}
+		log.Printf("Found offset %d from pagination token: %s", offset, in.PageToken)
+	}
 	var result []models.VhostGetControllersResult
 	err := s.rpc.Call("vhost_get_controllers", nil, &result)
 	if err != nil {
@@ -196,10 +216,10 @@ func (s *Server) ListVirtioScsiLuns(_ context.Context, in *pb.ListVirtioScsiLuns
 	log.Printf("Received from SPDK: %v", result)
 	var token string
 	if in.PageSize > 0 && int(in.PageSize) < len(result) {
-		log.Printf("Limiting result to: %d", in.PageSize)
-		result = result[:in.PageSize]
+		log.Printf("Limiting result to %d:%d", offset, in.PageSize)
+		result = result[offset:in.PageSize]
 		token = uuid.New().String()
-		s.Pagination[token] = int(in.PageSize)
+		s.Pagination[token] = offset + int(in.PageSize)
 	}
 	Blobarray := make([]*pb.VirtioScsiLun, len(result))
 	for i := range result {

--- a/pkg/frontend/scsi.go
+++ b/pkg/frontend/scsi.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 
 	pc "github.com/opiproject/opi-api/common/v1/gen/go"
 	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
@@ -81,7 +82,7 @@ func (s *Server) ListVirtioScsiControllers(_ context.Context, in *pb.ListVirtioS
 	}
 	size := 50
 	if in.PageSize > 0 {
-		size = int(in.PageSize)
+		size = int(math.Min(float64(in.PageSize), 250))
 	}
 	offset := 0
 	if in.PageToken != "" {
@@ -204,7 +205,7 @@ func (s *Server) ListVirtioScsiLuns(_ context.Context, in *pb.ListVirtioScsiLuns
 	}
 	size := 50
 	if in.PageSize > 0 {
-		size = int(in.PageSize)
+		size = int(math.Min(float64(in.PageSize), 250))
 	}
 	offset := 0
 	if in.PageToken != "" {

--- a/pkg/frontend/scsi.go
+++ b/pkg/frontend/scsi.go
@@ -81,7 +81,8 @@ func (s *Server) ListVirtioScsiControllers(_ context.Context, in *pb.ListVirtioS
 	}
 	offset := 0
 	if in.PageToken != "" {
-		offset, ok := s.Pagination[in.PageToken]
+		var ok bool
+		offset, ok = s.Pagination[in.PageToken]
 		if !ok {
 			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
 			log.Printf("error: %v", err)
@@ -199,7 +200,8 @@ func (s *Server) ListVirtioScsiLuns(_ context.Context, in *pb.ListVirtioScsiLuns
 	}
 	offset := 0
 	if in.PageToken != "" {
-		offset, ok := s.Pagination[in.PageToken]
+		var ok bool
+		offset, ok = s.Pagination[in.PageToken]
 		if !ok {
 			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
 			log.Printf("error: %v", err)

--- a/pkg/frontend/scsi.go
+++ b/pkg/frontend/scsi.go
@@ -87,10 +87,10 @@ func (s *Server) ListVirtioScsiControllers(_ context.Context, in *pb.ListVirtioS
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
-	var token string
-	if size < len(result) {
-		log.Printf("Limiting result to %d:%d", offset, size)
-		result = result[offset:size]
+	token := ""
+	log.Printf("Limiting result len(%d) to [%d:%d]", len(result), offset, size)
+	result, hasMoreElements := server.LimitPagination(result, offset, size)
+	if hasMoreElements {
 		token = uuid.New().String()
 		s.Pagination[token] = offset + size
 	}
@@ -195,10 +195,10 @@ func (s *Server) ListVirtioScsiLuns(_ context.Context, in *pb.ListVirtioScsiLuns
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
-	var token string
-	if size < len(result) {
-		log.Printf("Limiting result to %d:%d", offset, size)
-		result = result[offset:size]
+	token := ""
+	log.Printf("Limiting result len(%d) to [%d:%d]", len(result), offset, size)
+	result, hasMoreElements := server.LimitPagination(result, offset, size)
+	if hasMoreElements {
 		token = uuid.New().String()
 		s.Pagination[token] = offset + size
 	}

--- a/pkg/middleend/middleend.go
+++ b/pkg/middleend/middleend.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math"
 	"regexp"
 	"strings"
 
@@ -228,25 +227,10 @@ func (s *Server) UpdateEncryptedVolume(_ context.Context, in *pb.UpdateEncrypted
 // ListEncryptedVolumes lists encrypted volumes
 func (s *Server) ListEncryptedVolumes(_ context.Context, in *pb.ListEncryptedVolumesRequest) (*pb.ListEncryptedVolumesResponse, error) {
 	log.Printf("ListEncryptedVolumes: Received from client: %v", in)
-	if in.PageSize < 0 {
-		err := status.Error(codes.InvalidArgument, "negative PageSize is not allowed")
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	size := 50
-	if in.PageSize > 0 {
-		size = int(math.Min(float64(in.PageSize), 250))
-	}
-	offset := 0
-	if in.PageToken != "" {
-		var ok bool
-		offset, ok = s.Pagination[in.PageToken]
-		if !ok {
-			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
-			log.Printf("error: %v", err)
-			return nil, err
-		}
-		log.Printf("Found offset %d from pagination token: %s", offset, in.PageToken)
+	size, offset, perr := server.ExtractPagination(in.PageSize, in.PageToken, s.Pagination)
+	if perr != nil {
+		log.Printf("error: %v", perr)
+		return nil, perr
 	}
 	var result []models.BdevGetBdevsResult
 	err := s.rpc.Call("bdev_get_bdevs", nil, &result)

--- a/pkg/middleend/middleend.go
+++ b/pkg/middleend/middleend.go
@@ -232,6 +232,10 @@ func (s *Server) ListEncryptedVolumes(_ context.Context, in *pb.ListEncryptedVol
 		log.Printf("error: %v", err)
 		return nil, err
 	}
+	size := 50
+	if in.PageSize > 0 {
+		size = int(in.PageSize)
+	}
 	offset := 0
 	if in.PageToken != "" {
 		var ok bool
@@ -251,11 +255,11 @@ func (s *Server) ListEncryptedVolumes(_ context.Context, in *pb.ListEncryptedVol
 	}
 	log.Printf("Received from SPDK: %v", result)
 	var token string
-	if in.PageSize > 0 && int(in.PageSize) < len(result) {
-		log.Printf("Limiting result to %d:%d", offset, in.PageSize)
-		result = result[offset:in.PageSize]
+	if size < len(result) {
+		log.Printf("Limiting result to %d:%d", offset, size)
+		result = result[offset:size]
 		token = uuid.New().String()
-		s.Pagination[token] = offset + int(in.PageSize)
+		s.Pagination[token] = offset + size
 	}
 	Blobarray := make([]*pb.EncryptedVolume, len(result))
 	for i := range result {

--- a/pkg/middleend/middleend.go
+++ b/pkg/middleend/middleend.go
@@ -234,7 +234,8 @@ func (s *Server) ListEncryptedVolumes(_ context.Context, in *pb.ListEncryptedVol
 	}
 	offset := 0
 	if in.PageToken != "" {
-		offset, ok := s.Pagination[in.PageToken]
+		var ok bool
+		offset, ok = s.Pagination[in.PageToken]
 		if !ok {
 			err := status.Errorf(codes.NotFound, "unable to find pagination token %s", in.PageToken)
 			log.Printf("error: %v", err)

--- a/pkg/middleend/middleend.go
+++ b/pkg/middleend/middleend.go
@@ -239,10 +239,10 @@ func (s *Server) ListEncryptedVolumes(_ context.Context, in *pb.ListEncryptedVol
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
-	var token string
-	if size < len(result) {
-		log.Printf("Limiting result to %d:%d", offset, size)
-		result = result[offset:size]
+	token := ""
+	log.Printf("Limiting result len(%d) to [%d:%d]", len(result), offset, size)
+	result, hasMoreElements := server.LimitPagination(result, offset, size)
+	if hasMoreElements {
 		token = uuid.New().String()
 		s.Pagination[token] = offset + size
 	}

--- a/pkg/middleend/middleend.go
+++ b/pkg/middleend/middleend.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"regexp"
 	"strings"
 
@@ -234,7 +235,7 @@ func (s *Server) ListEncryptedVolumes(_ context.Context, in *pb.ListEncryptedVol
 	}
 	size := 50
 	if in.PageSize > 0 {
-		size = int(in.PageSize)
+		size = int(math.Min(float64(in.PageSize), 250))
 	}
 	offset := 0
 	if in.PageToken != "" {

--- a/pkg/middleend/middleend.go
+++ b/pkg/middleend/middleend.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opiproject/opi-spdk-bridge/pkg/models"
 	"github.com/opiproject/opi-spdk-bridge/pkg/server"
 
+	"github.com/google/uuid"
 	"github.com/ulule/deepcopier"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -27,14 +28,16 @@ import (
 type Server struct {
 	pb.UnimplementedMiddleendServiceServer
 
-	rpc server.JSONRPC
+	rpc        server.JSONRPC
+	Pagination map[string]int
 }
 
 // NewServer creates initialized instance of MiddleEnd server communicating
 // with provided jsonRPC
 func NewServer(jsonRPC server.JSONRPC) *Server {
 	return &Server{
-		rpc: jsonRPC,
+		rpc:        jsonRPC,
+		Pagination: make(map[string]int),
 	}
 }
 
@@ -236,16 +239,19 @@ func (s *Server) ListEncryptedVolumes(_ context.Context, in *pb.ListEncryptedVol
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
+	var token string
 	if in.PageSize > 0 && int(in.PageSize) < len(result) {
 		log.Printf("Limiting result to: %d", in.PageSize)
 		result = result[:in.PageSize]
+		token = uuid.New().String()
+		s.Pagination[token] = int(in.PageSize)
 	}
 	Blobarray := make([]*pb.EncryptedVolume, len(result))
 	for i := range result {
 		r := &result[i]
 		Blobarray[i] = &pb.EncryptedVolume{EncryptedVolumeId: &pc.ObjectKey{Value: r.Name}}
 	}
-	return &pb.ListEncryptedVolumesResponse{EncryptedVolumes: Blobarray}, nil
+	return &pb.ListEncryptedVolumesResponse{EncryptedVolumes: Blobarray, NextPageToken: token}, nil
 }
 
 // GetEncryptedVolume gets an encrypted volume

--- a/pkg/middleend/middleend_test.go
+++ b/pkg/middleend/middleend_test.go
@@ -551,7 +551,7 @@ func TestMiddleEnd_ListEncryptedVolumes(t *testing.T) {
 				}
 				// Empty NextPageToken indicates end of results list
 				if tt.size != 1 && response.NextPageToken != "" {
-					t.Error("response: expected", tt, "received", response)
+					t.Error("Expected end of results, receieved non-empty next page token", response.NextPageToken)
 				}
 			}
 

--- a/pkg/middleend/middleend_test.go
+++ b/pkg/middleend/middleend_test.go
@@ -527,6 +527,10 @@ func TestMiddleEnd_ListEncryptedVolumes(t *testing.T) {
 				if !reflect.DeepEqual(response.EncryptedVolumes, tt.out) {
 					t.Error("response: expected", tt.out, "received", response.EncryptedVolumes)
 				}
+				// Empty NextPageToken indicates end of results list
+				if tt.size != 1 && response.NextPageToken != "" {
+					t.Error("response: expected", tt, "received", response)
+				}
 			}
 
 			if err != nil {

--- a/pkg/server/utils.go
+++ b/pkg/server/utils.go
@@ -22,18 +22,18 @@ import (
 )
 
 // ExtractPagination is a helper function for List pagination to fetch PageSize and PageToken
-func ExtractPagination(pageSize int32, pageToken string, pagination map[string]int) (int, int, error) {
+func ExtractPagination(pageSize int32, pageToken string, pagination map[string]int) (size int, offset int, err error) {
 	if pageSize < 0 {
 		err := status.Error(codes.InvalidArgument, "negative PageSize is not allowed")
 		return -1, -1, err
 	}
 	// pick reasonable default and max sizes
-	size := 50
+	size = 50
 	if pageSize > 0 {
 		size = int(math.Min(float64(pageSize), 250))
 	}
 	// fetch offset from the database using opaque token
-	offset := 0
+	offset = 0
 	if pageToken != "" {
 		var ok bool
 		offset, ok = pagination[pageToken]

--- a/pkg/server/utils.go
+++ b/pkg/server/utils.go
@@ -23,14 +23,18 @@ import (
 
 // ExtractPagination is a helper function for List pagination to fetch PageSize and PageToken
 func ExtractPagination(pageSize int32, pageToken string, pagination map[string]int) (size int, offset int, err error) {
+	const (
+		maxPageSize     = 250
+		defaultPageSize = 50
+	)
 	if pageSize < 0 {
 		err := status.Error(codes.InvalidArgument, "negative PageSize is not allowed")
 		return -1, -1, err
 	}
 	// pick reasonable default and max sizes
-	size = 50
+	size = defaultPageSize
 	if pageSize > 0 {
-		size = int(math.Min(float64(pageSize), 250))
+		size = int(math.Min(float64(pageSize), maxPageSize))
 	}
 	// fetch offset from the database using opaque token
 	offset = 0


### PR DESCRIPTION
see https://google.aip.dev/132 and https://google.aip.dev/158

If API returned partial result:
- generate new NextPageToken based on UUID
- return the token in the response
- save the token to re-use later on
- Empty NextPageToken indicates end of results list

If non empty token received in API request:
- received token, find it in local DB and retrieve offset
- return results starting from offset

Token expiration is not implemeted yet.

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>