### PR TITLE
Add ability for KVM to assign devices on specific buses.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,18 +45,14 @@ func main() {
 	var ctrlrDir string
 	flag.StringVar(&ctrlrDir, "ctrlr_dir", "", "Directory with created SPDK device unix sockets (-S option in SPDK). Valid only with -kvm option")
 
-	var nvmeBusesStr string
-	flag.StringVar(&nvmeBusesStr, "nvme_buses", "", "QEMU PCI buses IDs separated by `:` to attach NVMe devices on. e.g. \"pci.opi.0:pci.opi.1\". Valid only with -kvm option")
-
-	var virtioBlkStr string
-	flag.StringVar(&virtioBlkStr, "virtio_blk_buses", "", "QEMU PCI buses IDs separated by `:` to attach virtio-blk devices on. e.g. \"pci.opi.0:pci.opi.1\". Valid only with -kvm option")
+	var busesStr string
+	flag.StringVar(&busesStr, "buses", "", "QEMU PCI buses IDs separated by `:` to attach Nvme/virtio-blk devices on. e.g. \"pci.opi.0:pci.opi.1\". Valid only with -kvm option")
 
 	var tcpTransportListenAddr string
 	flag.StringVar(&tcpTransportListenAddr, "tcp_trid", "127.0.0.1:4420", "ipv4 address:port (aka traddr:trsvcid) or ipv6 [address]:port tuple (aka [traddr]:trsvcid) to listen on for Nvme/TCP transport")
 	flag.Parse()
 
-	nvmeBuses := splitBusesBySeparator(nvmeBusesStr)
-	virtioBlkBuses := splitBusesBySeparator(virtioBlkStr)
+	buses := splitBusesBySeparator(busesStr)
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
@@ -72,7 +68,7 @@ func main() {
 		log.Println("Creating KVM server.")
 		frontendServer := frontend.NewServerWithSubsystemListener(jsonRPC,
 			kvm.NewVfiouserSubsystemListener(ctrlrDir))
-		kvmServer := kvm.NewServer(frontendServer, qmpAddress, ctrlrDir, nvmeBuses, virtioBlkBuses)
+		kvmServer := kvm.NewServer(frontendServer, qmpAddress, ctrlrDir, buses)
 
 		pb.RegisterFrontendNvmeServiceServer(s, kvmServer)
 		pb.RegisterFrontendVirtioBlkServiceServer(s, kvmServer)

--- a/pkg/kvm/blk.go
+++ b/pkg/kvm/blk.go
@@ -20,7 +20,7 @@ func (s *Server) CreateVirtioBlk(ctx context.Context, in *pb.CreateVirtioBlkRequ
 		return nil, errNoPcieEndpoint
 	}
 
-	location, err := s.virtioBlkDeviceLocator.Calculate(in.VirtioBlk.PcieId)
+	location, err := s.locator.Calculate(in.VirtioBlk.PcieId)
 	if err != nil {
 		log.Println("Failed to calculate device location:", err)
 		return nil, errDeviceEndpoint

--- a/pkg/kvm/blk_test.go
+++ b/pkg/kvm/blk_test.go
@@ -88,7 +88,7 @@ func TestCreateVirtioBlk(t *testing.T) {
 			if test.nonDefaultQmpAddress != "" {
 				qmpAddress = test.nonDefaultQmpAddress
 			}
-			kvmServer := NewServer(opiSpdkServer, qmpAddress, qmpServer.testDir)
+			kvmServer := NewServer(opiSpdkServer, qmpAddress, qmpServer.testDir, nil, nil)
 			kvmServer.timeout = qmplibTimeout
 
 			out, err := kvmServer.CreateVirtioBlk(context.Background(), testCreateVirtioBlkRequest)
@@ -173,7 +173,7 @@ func TestDeleteVirtioBlk(t *testing.T) {
 			if test.nonDefaultQmpAddress != "" {
 				qmpAddress = test.nonDefaultQmpAddress
 			}
-			kvmServer := NewServer(opiSpdkServer, qmpAddress, qmpServer.testDir)
+			kvmServer := NewServer(opiSpdkServer, qmpAddress, qmpServer.testDir, nil, nil)
 			kvmServer.timeout = qmplibTimeout
 
 			_, err := kvmServer.DeleteVirtioBlk(context.Background(), testDeleteVirtioBlkRequest)

--- a/pkg/kvm/blk_test.go
+++ b/pkg/kvm/blk_test.go
@@ -152,7 +152,7 @@ func TestCreateVirtioBlk(t *testing.T) {
 			if test.nonDefaultQmpAddress != "" {
 				qmpAddress = test.nonDefaultQmpAddress
 			}
-			kvmServer := NewServer(opiSpdkServer, qmpAddress, qmpServer.testDir, nil, test.buses)
+			kvmServer := NewServer(opiSpdkServer, qmpAddress, qmpServer.testDir, test.buses)
 			kvmServer.timeout = qmplibTimeout
 			request := proto.Clone(test.in).(*pb.CreateVirtioBlkRequest)
 
@@ -240,7 +240,7 @@ func TestDeleteVirtioBlk(t *testing.T) {
 			if test.nonDefaultQmpAddress != "" {
 				qmpAddress = test.nonDefaultQmpAddress
 			}
-			kvmServer := NewServer(opiSpdkServer, qmpAddress, qmpServer.testDir, nil, nil)
+			kvmServer := NewServer(opiSpdkServer, qmpAddress, qmpServer.testDir, nil)
 			kvmServer.timeout = qmplibTimeout
 			request := proto.Clone(testDeleteVirtioBlkRequest).(*pb.DeleteVirtioBlkRequest)
 

--- a/pkg/kvm/kvm.go
+++ b/pkg/kvm/kvm.go
@@ -30,6 +30,8 @@ var (
 	errInvalidSubsystem       = status.Error(codes.InvalidArgument, "invalid subsystem")
 	errDevicePartiallyDeleted = status.Error(codes.Internal, "device is partially deleted")
 	errFailedToCreateNvmeDir  = status.Error(codes.FailedPrecondition, "cannot create directory for Nvme controller")
+	errDeviceEndpoint         = status.Error(codes.InvalidArgument, "values in endpoint cannot be used to calculate device location")
+	errNoPcieEndpoint         = status.Error(codes.InvalidArgument, "no pcie endpoint provided")
 )
 
 // Server is a wrapper for default opi-spdk-bridge frontend which automates

--- a/pkg/kvm/kvm.go
+++ b/pkg/kvm/kvm.go
@@ -43,10 +43,13 @@ type Server struct {
 
 	timeout                time.Duration
 	pollDevicePresenceStep time.Duration
+
+	nvmeDeviceLocator      deviceLocator
+	virtioBlkDeviceLocator deviceLocator
 }
 
 // NewServer creates instance of KvmServer
-func NewServer(s *frontend.Server, qmpAddress string, ctrlrDir string) *Server {
+func NewServer(s *frontend.Server, qmpAddress string, ctrlrDir string, nvmeBuses []string, virtioBlkBuses []string) *Server {
 	if s == nil {
 		log.Fatalf("Frontend Server cannot be nil")
 	}
@@ -66,7 +69,8 @@ func NewServer(s *frontend.Server, qmpAddress string, ctrlrDir string) *Server {
 
 	timeout := 2 * time.Second
 	pollDevicePresenceStep := 5 * time.Millisecond
-	return &Server{s, qmpAddress, ctrlrDir, qmpProtocol, timeout, pollDevicePresenceStep}
+	return &Server{s, qmpAddress, ctrlrDir, qmpProtocol, timeout, pollDevicePresenceStep,
+		newDeviceLocator(nvmeBuses, nvmeDeviceType), newDeviceLocator(virtioBlkBuses, virtioBlkDeviceType)}
 }
 
 func getProtocol(qmpAddress string) (string, error) {

--- a/pkg/kvm/kvm.go
+++ b/pkg/kvm/kvm.go
@@ -46,12 +46,11 @@ type Server struct {
 	timeout                time.Duration
 	pollDevicePresenceStep time.Duration
 
-	nvmeDeviceLocator      deviceLocator
-	virtioBlkDeviceLocator deviceLocator
+	locator deviceLocator
 }
 
 // NewServer creates instance of KvmServer
-func NewServer(s *frontend.Server, qmpAddress string, ctrlrDir string, nvmeBuses []string, virtioBlkBuses []string) *Server {
+func NewServer(s *frontend.Server, qmpAddress string, ctrlrDir string, buses []string) *Server {
 	if s == nil {
 		log.Fatalf("Frontend Server cannot be nil")
 	}
@@ -71,8 +70,13 @@ func NewServer(s *frontend.Server, qmpAddress string, ctrlrDir string, nvmeBuses
 
 	timeout := 2 * time.Second
 	pollDevicePresenceStep := 5 * time.Millisecond
-	return &Server{s, qmpAddress, ctrlrDir, qmpProtocol, timeout, pollDevicePresenceStep,
-		newDeviceLocator(nvmeBuses, nvmeDeviceType), newDeviceLocator(virtioBlkBuses, virtioBlkDeviceType)}
+	return &Server{s,
+		qmpAddress,
+		ctrlrDir,
+		qmpProtocol,
+		timeout,
+		pollDevicePresenceStep,
+		newDeviceLocator(buses)}
 }
 
 func getProtocol(qmpAddress string) (string, error) {

--- a/pkg/kvm/kvm_test.go
+++ b/pkg/kvm/kvm_test.go
@@ -125,6 +125,16 @@ func (s *mockQmpCalls) ExpectAddVirtioBlk(id string, chardevID string) *mockQmpC
 	return s
 }
 
+func (s *mockQmpCalls) ExpectAddVirtioBlkWithAddress(id string, chardevID string, bus string, pf uint32) *mockQmpCalls {
+	s.ExpectAddVirtioBlk(id, chardevID)
+	index := len(s.expectedCalls) - 1
+	s.expectedCalls[index].expectedArgs =
+		append(s.expectedCalls[index].expectedArgs, `"bus":"`+bus+`"`)
+	s.expectedCalls[index].expectedArgs =
+		append(s.expectedCalls[index].expectedArgs, `"addr":"`+fmt.Sprintf("%#x", pf)+`"`)
+	return s
+}
+
 func (s *mockQmpCalls) ExpectAddNvmeController(id string, ctrlrDir string) *mockQmpCalls {
 	s.expectedCalls = append(s.expectedCalls, mockCall{
 		response: genericQmpOk,

--- a/pkg/kvm/kvm_test.go
+++ b/pkg/kvm/kvm_test.go
@@ -6,6 +6,7 @@ package kvm
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"net"
 	"os"
@@ -136,6 +137,16 @@ func (s *mockQmpCalls) ExpectAddNvmeController(id string, ctrlrDir string) *mock
 			regexp.MustCompile(`"socket":"` + pathRegexpStr + ctrlrDir + `/cntrl"`),
 		},
 	})
+	return s
+}
+
+func (s *mockQmpCalls) ExpectAddNvmeControllerWithAddress(id string, ctrlDir string, bus string, pf uint32) *mockQmpCalls {
+	s.ExpectAddNvmeController(id, ctrlDir)
+	index := len(s.expectedCalls) - 1
+	s.expectedCalls[index].expectedArgs =
+		append(s.expectedCalls[index].expectedArgs, `"bus":"`+bus+`"`)
+	s.expectedCalls[index].expectedArgs =
+		append(s.expectedCalls[index].expectedArgs, `"addr":"`+fmt.Sprintf("%#x", pf)+`"`)
 	return s
 }
 

--- a/pkg/kvm/location.go
+++ b/pkg/kvm/location.go
@@ -11,11 +11,6 @@ import (
 	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
 )
 
-const (
-	virtioBlkDeviceType = "virtio-blk"
-	nvmeDeviceType      = "NVMe"
-)
-
 type deviceLocation struct {
 	Bus  *string
 	Addr *string
@@ -25,22 +20,22 @@ type deviceLocator interface {
 	Calculate(endpoint *pb.PciEndpoint) (deviceLocation, error)
 }
 
-func newDeviceLocator(buses []string, deviceType string) deviceLocator {
+func newDeviceLocator(buses []string) deviceLocator {
 	if len(buses) == 0 {
-		log.Println(deviceType, "location will be assigned by QEMU")
+		log.Println("Device location for virtio-blk and Nvme devices will be assigned by QEMU")
 		return defaultDeviceLocator{}
 	}
 	elementSet := make(map[string]struct{})
 	for _, bus := range buses {
 		if bus == "" {
-			log.Panicln("Empty bus name cannot be used in", buses, "for", deviceType)
+			log.Panicln("Empty bus name cannot be used in", buses)
 		}
 		if _, ok := elementSet[bus]; ok {
-			log.Panicln("Duplicated bus", bus, "for", deviceType)
+			log.Panicln("Duplicated bus", bus)
 		}
 		elementSet[bus] = struct{}{}
 	}
-	log.Println(deviceType, "device location will be calculated based on requested PcieEndpoint on ", buses)
+	log.Println("Device location will be calculated based on requested PcieEndpoint on", buses)
 	return busDeviceLocator{buses}
 }
 

--- a/pkg/kvm/location.go
+++ b/pkg/kvm/location.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Intel Corporation
+
+// Package kvm automates plugging of SPDK devices to a QEMU instance
+package kvm
+
+import (
+	"log"
+
+	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+)
+
+const (
+	virtioBlkDeviceType = "virtio-blk"
+	nvmeDeviceType      = "NVMe"
+)
+
+type deviceLocation struct {
+	Bus  *string
+	Addr *string
+}
+
+type deviceLocator interface {
+	Calculate(endpoint *pb.PciEndpoint) (deviceLocation, error)
+}
+
+func newDeviceLocator(buses []string, deviceType string) deviceLocator {
+	if len(buses) == 0 {
+		log.Println(deviceType, "location will be assigned by QEMU")
+		return defaultDeviceLocator{}
+	}
+	return nil
+}
+
+type defaultDeviceLocator struct{}
+
+func (defaultDeviceLocator) Calculate(_ *pb.PciEndpoint) (deviceLocation, error) {
+	return deviceLocation{
+		Bus:  nil,
+		Addr: nil,
+	}, nil
+}

--- a/pkg/kvm/location_test.go
+++ b/pkg/kvm/location_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Intel Corporation
+
+// Package kvm automates plugging of SPDK devices to a QEMU instance
+package kvm
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewDeviceLocator(t *testing.T) {
+	tests := map[string]struct {
+		buses         []string
+		wantPanic     bool
+		expectLocator deviceLocator
+	}{
+		"random device locator on not provided buses": {
+			buses:         []string{},
+			wantPanic:     false,
+			expectLocator: defaultDeviceLocator{},
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if (r != nil) != test.wantPanic {
+					t.Errorf("newDeviceLocator() recover = %v, wantPanic = %v", r, test.wantPanic)
+				}
+			}()
+			before := newDeviceLocator(test.buses, nvmeDeviceType)
+			if !reflect.DeepEqual(before, test.expectLocator) {
+				t.Error("response: expected", test.expectLocator, "received", before)
+			}
+		})
+	}
+}

--- a/pkg/kvm/location_test.go
+++ b/pkg/kvm/location_test.go
@@ -20,6 +20,23 @@ func TestNewDeviceLocator(t *testing.T) {
 			wantPanic:     false,
 			expectLocator: defaultDeviceLocator{},
 		},
+		"bus device locator on provided buses": {
+			buses:     []string{"bus.opi.0", "bus.opi.1"},
+			wantPanic: false,
+			expectLocator: busDeviceLocator{
+				buses: []string{"bus.opi.0", "bus.opi.1"},
+			},
+		},
+		"panic on empty bus": {
+			buses:         []string{"bus.opi.0", ""},
+			wantPanic:     true,
+			expectLocator: nil,
+		},
+		"panic on duplicated bus": {
+			buses:         []string{"bus.opi.0", "bus.opi.0"},
+			wantPanic:     true,
+			expectLocator: nil,
+		},
 	}
 
 	for testName, test := range tests {

--- a/pkg/kvm/location_test.go
+++ b/pkg/kvm/location_test.go
@@ -47,7 +47,7 @@ func TestNewDeviceLocator(t *testing.T) {
 					t.Errorf("newDeviceLocator() recover = %v, wantPanic = %v", r, test.wantPanic)
 				}
 			}()
-			before := newDeviceLocator(test.buses, nvmeDeviceType)
+			before := newDeviceLocator(test.buses)
 			if !reflect.DeepEqual(before, test.expectLocator) {
 				t.Error("response: expected", test.expectLocator, "received", before)
 			}

--- a/pkg/kvm/monitor.go
+++ b/pkg/kvm/monitor.go
@@ -71,14 +71,18 @@ func (m *monitor) DeleteChardev(id string) error {
 	return m.rmon.ChardevRemove(id)
 }
 
-func (m *monitor) AddVirtioBlkDevice(id string, chardevID string) error {
+func (m *monitor) AddVirtioBlkDevice(id string, chardevID string, location deviceLocation) error {
 	qmpCmd := struct {
 		Driver  string  `json:"driver"`
 		ID      *string `json:"id,omitempty"`
+		Bus     *string `json:"bus,omitempty"`
+		Addr    *string `json:"addr,omitempty"`
 		Chardev *string `json:"chardev,omitempty"`
 	}{
 		Driver:  "vhost-user-blk-pci",
 		ID:      &id,
+		Bus:     location.Bus,
+		Addr:    location.Addr,
 		Chardev: &chardevID,
 	}
 	if err := m.addDevice(qmpCmd); err != nil {

--- a/pkg/kvm/monitor.go
+++ b/pkg/kvm/monitor.go
@@ -87,15 +87,19 @@ func (m *monitor) AddVirtioBlkDevice(id string, chardevID string) error {
 	return m.waitForDeviceExist(id)
 }
 
-func (m *monitor) AddNvmeControllerDevice(id string, ctrlrDir string) error {
+func (m *monitor) AddNvmeControllerDevice(id string, ctrlrDir string, location deviceLocation) error {
 	socket := filepath.Join(ctrlrDir, "cntrl")
 	qmpCmd := struct {
 		Driver string  `json:"driver"`
 		ID     *string `json:"id,omitempty"`
+		Bus    *string `json:"bus,omitempty"`
+		Addr   *string `json:"addr,omitempty"`
 		Socket *string `json:"socket,omitempty"`
 	}{
 		Driver: "vfio-user-pci",
 		ID:     &id,
+		Bus:    location.Bus,
+		Addr:   location.Addr,
 		Socket: &socket,
 	}
 	if err := m.addDevice(qmpCmd); err != nil {

--- a/pkg/kvm/nvme.go
+++ b/pkg/kvm/nvme.go
@@ -60,7 +60,7 @@ func (s *Server) CreateNvmeController(ctx context.Context, in *pb.CreateNvmeCont
 		log.Println("Pci endpoint should be specified")
 		return nil, errNoPcieEndpoint
 	}
-	location, err := s.nvmeDeviceLocator.Calculate(in.NvmeController.Spec.PcieId)
+	location, err := s.locator.Calculate(in.NvmeController.Spec.PcieId)
 	if err != nil {
 		log.Println("Failed to calculate device location: ", err)
 		return nil, errDeviceEndpoint

--- a/pkg/kvm/nvme_test.go
+++ b/pkg/kvm/nvme_test.go
@@ -282,7 +282,7 @@ func TestCreateNvmeController(t *testing.T) {
 			if test.nonDefaultQmpAddress != "" {
 				qmpAddress = test.nonDefaultQmpAddress
 			}
-			kvmServer := NewServer(opiSpdkServer, qmpAddress, qmpServer.testDir, test.buses, nil)
+			kvmServer := NewServer(opiSpdkServer, qmpAddress, qmpServer.testDir, test.buses)
 			kvmServer.timeout = qmplibTimeout
 			testCtrlrDir := controllerDirPath(qmpServer.testDir, testSubsystemID)
 			if test.ctrlrDirExistsBeforeOperation &&
@@ -415,7 +415,7 @@ func TestDeleteNvmeController(t *testing.T) {
 			if test.nonDefaultQmpAddress != "" {
 				qmpAddress = test.nonDefaultQmpAddress
 			}
-			kvmServer := NewServer(opiSpdkServer, qmpAddress, qmpServer.testDir, nil, nil)
+			kvmServer := NewServer(opiSpdkServer, qmpAddress, qmpServer.testDir, nil)
 			kvmServer.timeout = qmplibTimeout
 			testCtrlrDir := controllerDirPath(qmpServer.testDir, testSubsystemID)
 			if test.ctrlrDirExistsBeforeOperation {

--- a/pkg/kvm/nvme_test.go
+++ b/pkg/kvm/nvme_test.go
@@ -184,7 +184,7 @@ func TestCreateNvmeController(t *testing.T) {
 			if test.nonDefaultQmpAddress != "" {
 				qmpAddress = test.nonDefaultQmpAddress
 			}
-			kvmServer := NewServer(opiSpdkServer, qmpAddress, qmpServer.testDir)
+			kvmServer := NewServer(opiSpdkServer, qmpAddress, qmpServer.testDir, nil, nil)
 			kvmServer.timeout = qmplibTimeout
 			testCtrlrDir := controllerDirPath(qmpServer.testDir, testSubsystemID)
 			if test.ctrlrDirExistsBeforeOperation &&
@@ -320,7 +320,7 @@ func TestDeleteNvmeController(t *testing.T) {
 			if test.nonDefaultQmpAddress != "" {
 				qmpAddress = test.nonDefaultQmpAddress
 			}
-			kvmServer := NewServer(opiSpdkServer, qmpAddress, qmpServer.testDir)
+			kvmServer := NewServer(opiSpdkServer, qmpAddress, qmpServer.testDir, nil, nil)
 			kvmServer.timeout = qmplibTimeout
 			testCtrlrDir := controllerDirPath(qmpServer.testDir, testSubsystemID)
 			if test.ctrlrDirExistsBeforeOperation {


### PR DESCRIPTION
QEMU QMP provides an ability to assign devices on a specific bus with a specific address. This can be useful if we need an ability to identify a created device within a running VM