### PR TITLE
QoS on device level for NVMe

### DIFF
--- a/pkg/frontend/nvme.go
+++ b/pkg/frontend/nvme.go
@@ -316,6 +316,11 @@ func (s *Server) DeleteNVMeController(_ context.Context, in *pb.DeleteNVMeContro
 // UpdateNVMeController updates an NVMe controller
 func (s *Server) UpdateNVMeController(_ context.Context, in *pb.UpdateNVMeControllerRequest) (*pb.NVMeController, error) {
 	log.Printf("UpdateNVMeController: Received from client: %v", in)
+	if err := s.verifyNVMeController(in.NvMeController); err != nil {
+		log.Printf("error: %v", err)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	s.Nvme.Controllers[in.NvMeController.Spec.Id.Value] = in.NvMeController
 	s.Nvme.Controllers[in.NvMeController.Spec.Id.Value].Status = &pb.NVMeControllerStatus{Active: true}
 	response := &pb.NVMeController{}

--- a/pkg/frontend/nvme_test.go
+++ b/pkg/frontend/nvme_test.go
@@ -804,6 +804,42 @@ func TestFrontEnd_UpdateNVMeController(t *testing.T) {
 		errMsg  string
 		start   bool
 	}{
+		"limit_min is not supported": {
+			&pb.NVMeController{
+				Spec: &pb.NVMeControllerSpec{
+					Id:               &pc.ObjectKey{Value: "controller-test"},
+					SubsystemId:      &pc.ObjectKey{Value: "subsystem-test"},
+					PcieId:           &pb.PciEndpoint{PhysicalFunction: 1, VirtualFunction: 2},
+					NvmeControllerId: 1,
+					MinLimit: &pb.QosLimit{
+						RwIopsKiops: 1,
+					},
+				},
+			},
+			nil,
+			[]string{},
+			codes.InvalidArgument,
+			"limit_min is not supported",
+			false,
+		},
+		"limit_max is not supported": {
+			&pb.NVMeController{
+				Spec: &pb.NVMeControllerSpec{
+					Id:               &pc.ObjectKey{Value: "controller-test"},
+					SubsystemId:      &pc.ObjectKey{Value: "subsystem-test"},
+					PcieId:           &pb.PciEndpoint{PhysicalFunction: 1, VirtualFunction: 2},
+					NvmeControllerId: 1,
+					MaxLimit: &pb.QosLimit{
+						RwIopsKiops: 1,
+					},
+				},
+			},
+			nil,
+			[]string{},
+			codes.InvalidArgument,
+			"limit_max is not supported",
+			false,
+		},
 		"valid request without SPDK": {
 			&pb.NVMeController{
 				Spec: spec,

--- a/pkg/frontend/nvme_test.go
+++ b/pkg/frontend/nvme_test.go
@@ -607,6 +607,44 @@ func TestFrontEnd_CreateNVMeController(t *testing.T) {
 		start   bool
 		exist   bool
 	}{
+		"limit_min is not supported": {
+			&pb.NVMeController{
+				Spec: &pb.NVMeControllerSpec{
+					Id:               &pc.ObjectKey{Value: "controller-test"},
+					SubsystemId:      &pc.ObjectKey{Value: "subsystem-test"},
+					PcieId:           &pb.PciEndpoint{PhysicalFunction: 1, VirtualFunction: 2},
+					NvmeControllerId: 1,
+					MinLimit: &pb.QosLimit{
+						RwIopsKiops: 1,
+					},
+				},
+			},
+			nil,
+			[]string{},
+			codes.InvalidArgument,
+			"limit_min is not supported",
+			false,
+			false,
+		},
+		"limit_max is not supported": {
+			&pb.NVMeController{
+				Spec: &pb.NVMeControllerSpec{
+					Id:               &pc.ObjectKey{Value: "controller-test"},
+					SubsystemId:      &pc.ObjectKey{Value: "subsystem-test"},
+					PcieId:           &pb.PciEndpoint{PhysicalFunction: 1, VirtualFunction: 2},
+					NvmeControllerId: 1,
+					MaxLimit: &pb.QosLimit{
+						RwIopsKiops: 1,
+					},
+				},
+			},
+			nil,
+			[]string{},
+			codes.InvalidArgument,
+			"limit_max is not supported",
+			false,
+			false,
+		},
 		"valid request with invalid SPDK response": {
 			&pb.NVMeController{
 				Spec: &pb.NVMeControllerSpec{


### PR DESCRIPTION
Report invalid argument for QoS on device level NVMe since SPDK supports only volume level limits