### PR TITLE
create: log {resource}_id field if provided by user

### DIFF
--- a/pkg/backend/aio.go
+++ b/pkg/backend/aio.go
@@ -32,6 +32,10 @@ func sortAioControllers(controllers []*pb.AioController) {
 // CreateAioController creates an Aio controller
 func (s *Server) CreateAioController(_ context.Context, in *pb.CreateAioControllerRequest) (*pb.AioController, error) {
 	log.Printf("CreateAioController: Received from client: %v", in)
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.AioControllerId != "" {
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.AioControllerId, in.AioController.Handle.Value)
+	}
 	// idempotent API when called with same key, should return same object
 	volume, ok := s.Volumes.AioVolumes[in.AioController.Handle.Value]
 	if ok {

--- a/pkg/backend/null.go
+++ b/pkg/backend/null.go
@@ -32,6 +32,10 @@ func sortNullDebugs(nullDebugs []*pb.NullDebug) {
 // CreateNullDebug creates a Null Debug instance
 func (s *Server) CreateNullDebug(_ context.Context, in *pb.CreateNullDebugRequest) (*pb.NullDebug, error) {
 	log.Printf("CreateNullDebug: Received from client: %v", in)
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.NullDebugId != "" {
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NullDebugId, in.NullDebug.Handle.Value)
+	}
 	// idempotent API when called with same key, should return same object
 	volume, ok := s.Volumes.NullVolumes[in.NullDebug.Handle.Value]
 	if ok {

--- a/pkg/backend/nvme.go
+++ b/pkg/backend/nvme.go
@@ -33,6 +33,10 @@ func sortNVMfRemoteControllers(controllers []*pb.NVMfRemoteController) {
 // CreateNVMfRemoteController creates an NVMf remote controller
 func (s *Server) CreateNVMfRemoteController(_ context.Context, in *pb.CreateNVMfRemoteControllerRequest) (*pb.NVMfRemoteController, error) {
 	log.Printf("CreateNVMfRemoteController: Received from client: %v", in)
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.NvMfRemoteControllerId != "" {
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMfRemoteControllerId, in.NvMfRemoteController.Id.Value)
+	}
 	// idempotent API when called with same key, should return same object
 	volume, ok := s.Volumes.NvmeVolumes[in.NvMfRemoteController.Id.Value]
 	if ok {

--- a/pkg/frontend/blk.go
+++ b/pkg/frontend/blk.go
@@ -32,6 +32,10 @@ func sortVirtioBlks(virtioBlks []*pb.VirtioBlk) {
 // CreateVirtioBlk creates a Virtio block device
 func (s *Server) CreateVirtioBlk(_ context.Context, in *pb.CreateVirtioBlkRequest) (*pb.VirtioBlk, error) {
 	log.Printf("CreateVirtioBlk: Received from client: %v", in)
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.VirtioBlkId != "" {
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioBlkId, in.VirtioBlk.Id.Value)
+	}
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.Virt.BlkCtrls[in.VirtioBlk.Id.Value]
 	if ok {

--- a/pkg/frontend/nvme.go
+++ b/pkg/frontend/nvme.go
@@ -97,6 +97,10 @@ func (c *tcpSubsystemListener) Params(_ *pb.NVMeController, nqn string) spdk.Nvm
 // CreateNVMeSubsystem creates an NVMe Subsystem
 func (s *Server) CreateNVMeSubsystem(_ context.Context, in *pb.CreateNVMeSubsystemRequest) (*pb.NVMeSubsystem, error) {
 	log.Printf("CreateNVMeSubsystem: Received from client: %v", in)
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.NvMeSubsystemId != "" {
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeSubsystemId, in.NvMeSubsystem.Spec.Id.Value)
+	}
 	// idempotent API when called with same key, should return same object
 	subsys, ok := s.Nvme.Subsystems[in.NvMeSubsystem.Spec.Id.Value]
 	if ok {
@@ -254,6 +258,10 @@ func (s *Server) NVMeSubsystemStats(_ context.Context, in *pb.NVMeSubsystemStats
 // CreateNVMeController creates an NVMe controller
 func (s *Server) CreateNVMeController(_ context.Context, in *pb.CreateNVMeControllerRequest) (*pb.NVMeController, error) {
 	log.Printf("Received from client: %v", in.NvMeController)
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.NvMeControllerId != "" {
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeControllerId, in.NvMeController.Spec.Id.Value)
+	}
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.Nvme.Controllers[in.NvMeController.Spec.Id.Value]
 	if ok {
@@ -377,6 +385,10 @@ func (s *Server) NVMeControllerStats(_ context.Context, in *pb.NVMeControllerSta
 // CreateNVMeNamespace creates an NVMe namespace
 func (s *Server) CreateNVMeNamespace(_ context.Context, in *pb.CreateNVMeNamespaceRequest) (*pb.NVMeNamespace, error) {
 	log.Printf("CreateNVMeNamespace: Received from client: %v", in)
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.NvMeNamespaceId != "" {
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeNamespaceId, in.NvMeNamespace.Spec.Id.Value)
+	}
 	// idempotent API when called with same key, should return same object
 	namespace, ok := s.Nvme.Namespaces[in.NvMeNamespace.Spec.Id.Value]
 	if ok {

--- a/pkg/frontend/scsi.go
+++ b/pkg/frontend/scsi.go
@@ -32,6 +32,10 @@ func sortScsiControllers(controllers []*pb.VirtioScsiController) {
 // CreateVirtioScsiController creates a Virtio SCSI controller
 func (s *Server) CreateVirtioScsiController(_ context.Context, in *pb.CreateVirtioScsiControllerRequest) (*pb.VirtioScsiController, error) {
 	log.Printf("CreateVirtioScsiController: Received from client: %v", in)
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.VirtioScsiControllerId != "" {
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioScsiControllerId, in.VirtioScsiController.Id.Value)
+	}
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.Virt.ScsiCtrls[in.VirtioScsiController.Id.Value]
 	if ok {
@@ -159,6 +163,10 @@ func (s *Server) VirtioScsiControllerStats(_ context.Context, in *pb.VirtioScsiC
 // CreateVirtioScsiLun creates a Virtio SCSI LUN
 func (s *Server) CreateVirtioScsiLun(_ context.Context, in *pb.CreateVirtioScsiLunRequest) (*pb.VirtioScsiLun, error) {
 	log.Printf("CreateVirtioScsiLun: Received from client: %v", in)
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.VirtioScsiLunId != "" {
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioScsiLunId, in.VirtioScsiLun.Id.Value)
+	}
 	// idempotent API when called with same key, should return same object
 	lun, ok := s.Virt.ScsiLuns[in.VirtioScsiLun.Id.Value]
 	if ok {


### PR DESCRIPTION
see https://google.aip.dev/133#user-specified-ids
this commit is preparation to handle `{resource}_id` properly

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
