### PR TITLE
create: use {resource}_id field if provided by user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       test: grpcurl -plaintext localhost:50051 list || exit 1
 
   opi-spdk-client:
-    image: ghcr.io/opiproject/godpu:main@sha256:8344fd0cd7169bb03503ffd173feacfc021a252f033d894cc12c142a44cb1ea4
+    image: ghcr.io/opiproject/godpu:main@sha256:d0acf6f335b21e9472b86ea1bef55528e9ec92dfe0cd4e610a1cc3ee806abda2
     networks:
       - opi
     depends_on:

--- a/pkg/backend/aio.go
+++ b/pkg/backend/aio.go
@@ -33,9 +33,12 @@ func sortAioControllers(controllers []*pb.AioController) {
 func (s *Server) CreateAioController(_ context.Context, in *pb.CreateAioControllerRequest) (*pb.AioController, error) {
 	log.Printf("CreateAioController: Received from client: %v", in)
 	// see https://google.aip.dev/133#user-specified-ids
+	name := uuid.New().String()
 	if in.AioControllerId != "" {
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.AioControllerId, in.AioController.Handle.Value)
+		name = in.AioControllerId
 	}
+	in.AioController.Handle.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
 	// idempotent API when called with same key, should return same object
 	volume, ok := s.Volumes.AioVolumes[in.AioController.Handle.Value]
 	if ok {

--- a/pkg/backend/aio.go
+++ b/pkg/backend/aio.go
@@ -38,7 +38,7 @@ func (s *Server) CreateAioController(_ context.Context, in *pb.CreateAioControll
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.AioControllerId, in.AioController.Handle.Value)
 		name = in.AioControllerId
 	}
-	in.AioController.Handle.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
+	in.AioController.Handle.Value = name
 	// idempotent API when called with same key, should return same object
 	volume, ok := s.Volumes.AioVolumes[in.AioController.Handle.Value]
 	if ok {

--- a/pkg/backend/aio_test.go
+++ b/pkg/backend/aio_test.go
@@ -105,7 +105,7 @@ func TestBackEnd_CreateAioController(t *testing.T) {
 				testEnv.opiSpdkServer.Volumes.AioVolumes[testAioVolume.Handle.Value] = &testAioVolume
 			}
 
-			request := &pb.CreateAioControllerRequest{AioController: tt.in}
+			request := &pb.CreateAioControllerRequest{AioController: tt.in, AioControllerId: "mytest"}
 			response, err := testEnv.client.CreateAioController(testEnv.ctx, request)
 			if response != nil {
 				// Marshall the request and response, so we can just compare the contained data

--- a/pkg/backend/null.go
+++ b/pkg/backend/null.go
@@ -33,9 +33,12 @@ func sortNullDebugs(nullDebugs []*pb.NullDebug) {
 func (s *Server) CreateNullDebug(_ context.Context, in *pb.CreateNullDebugRequest) (*pb.NullDebug, error) {
 	log.Printf("CreateNullDebug: Received from client: %v", in)
 	// see https://google.aip.dev/133#user-specified-ids
+	name := uuid.New().String()
 	if in.NullDebugId != "" {
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NullDebugId, in.NullDebug.Handle.Value)
+		name = in.NullDebugId
 	}
+	in.NullDebug.Handle.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
 	// idempotent API when called with same key, should return same object
 	volume, ok := s.Volumes.NullVolumes[in.NullDebug.Handle.Value]
 	if ok {

--- a/pkg/backend/null.go
+++ b/pkg/backend/null.go
@@ -38,7 +38,7 @@ func (s *Server) CreateNullDebug(_ context.Context, in *pb.CreateNullDebugReques
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NullDebugId, in.NullDebug.Handle.Value)
 		name = in.NullDebugId
 	}
-	in.NullDebug.Handle.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
+	in.NullDebug.Handle.Value = name
 	// idempotent API when called with same key, should return same object
 	volume, ok := s.Volumes.NullVolumes[in.NullDebug.Handle.Value]
 	if ok {

--- a/pkg/backend/null_test.go
+++ b/pkg/backend/null_test.go
@@ -104,7 +104,7 @@ func TestBackEnd_CreateNullDebug(t *testing.T) {
 				testEnv.opiSpdkServer.Volumes.NullVolumes[testNullVolume.Handle.Value] = &testNullVolume
 			}
 
-			request := &pb.CreateNullDebugRequest{NullDebug: tt.in}
+			request := &pb.CreateNullDebugRequest{NullDebug: tt.in, NullDebugId: "mytest"}
 			response, err := testEnv.client.CreateNullDebug(testEnv.ctx, request)
 			if response != nil {
 				// Marshall the request and response, so we can just compare the contained data

--- a/pkg/backend/nvme.go
+++ b/pkg/backend/nvme.go
@@ -34,9 +34,12 @@ func sortNVMfRemoteControllers(controllers []*pb.NVMfRemoteController) {
 func (s *Server) CreateNVMfRemoteController(_ context.Context, in *pb.CreateNVMfRemoteControllerRequest) (*pb.NVMfRemoteController, error) {
 	log.Printf("CreateNVMfRemoteController: Received from client: %v", in)
 	// see https://google.aip.dev/133#user-specified-ids
+	name := uuid.New().String()
 	if in.NvMfRemoteControllerId != "" {
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMfRemoteControllerId, in.NvMfRemoteController.Id.Value)
+		name = in.NvMfRemoteControllerId
 	}
+	in.NvMfRemoteController.Id.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
 	// idempotent API when called with same key, should return same object
 	volume, ok := s.Volumes.NvmeVolumes[in.NvMfRemoteController.Id.Value]
 	if ok {

--- a/pkg/backend/nvme.go
+++ b/pkg/backend/nvme.go
@@ -39,7 +39,7 @@ func (s *Server) CreateNVMfRemoteController(_ context.Context, in *pb.CreateNVMf
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMfRemoteControllerId, in.NvMfRemoteController.Id.Value)
 		name = in.NvMfRemoteControllerId
 	}
-	in.NvMfRemoteController.Id.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
+	in.NvMfRemoteController.Id.Value = name
 	// idempotent API when called with same key, should return same object
 	volume, ok := s.Volumes.NvmeVolumes[in.NvMfRemoteController.Id.Value]
 	if ok {

--- a/pkg/backend/nvme_test.go
+++ b/pkg/backend/nvme_test.go
@@ -106,7 +106,7 @@ func TestBackEnd_CreateNVMfRemoteController(t *testing.T) {
 				testEnv.opiSpdkServer.Volumes.NvmeVolumes[controller.Id.Value] = controller
 			}
 
-			request := &pb.CreateNVMfRemoteControllerRequest{NvMfRemoteController: tt.in}
+			request := &pb.CreateNVMfRemoteControllerRequest{NvMfRemoteController: tt.in, NvMfRemoteControllerId: "OpiNvme8"}
 			response, err := testEnv.client.CreateNVMfRemoteController(testEnv.ctx, request)
 			if response != nil {
 				// if !reflect.DeepEqual(response, tt.out) {

--- a/pkg/frontend/blk.go
+++ b/pkg/frontend/blk.go
@@ -33,9 +33,12 @@ func sortVirtioBlks(virtioBlks []*pb.VirtioBlk) {
 func (s *Server) CreateVirtioBlk(_ context.Context, in *pb.CreateVirtioBlkRequest) (*pb.VirtioBlk, error) {
 	log.Printf("CreateVirtioBlk: Received from client: %v", in)
 	// see https://google.aip.dev/133#user-specified-ids
+	name := uuid.New().String()
 	if in.VirtioBlkId != "" {
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioBlkId, in.VirtioBlk.Id.Value)
+		name = in.VirtioBlkId
 	}
+	in.VirtioBlk.Id.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.Virt.BlkCtrls[in.VirtioBlk.Id.Value]
 	if ok {

--- a/pkg/frontend/blk.go
+++ b/pkg/frontend/blk.go
@@ -38,7 +38,7 @@ func (s *Server) CreateVirtioBlk(_ context.Context, in *pb.CreateVirtioBlkReques
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioBlkId, in.VirtioBlk.Id.Value)
 		name = in.VirtioBlkId
 	}
-	in.VirtioBlk.Id.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
+	in.VirtioBlk.Id.Value = name
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.Virt.BlkCtrls[in.VirtioBlk.Id.Value]
 	if ok {

--- a/pkg/frontend/blk_test.go
+++ b/pkg/frontend/blk_test.go
@@ -63,7 +63,7 @@ func TestFrontEnd_CreateVirtioBlk(t *testing.T) {
 			testEnv := createTestEnvironment(true, test.spdk)
 			defer testEnv.Close()
 
-			request := &pb.CreateVirtioBlkRequest{VirtioBlk: test.in}
+			request := &pb.CreateVirtioBlkRequest{VirtioBlk: test.in, VirtioBlkId: "virtio-blk-42"}
 			response, err := testEnv.client.CreateVirtioBlk(testEnv.ctx, request)
 			if response != nil {
 				wantOut, _ := proto.Marshal(test.out)

--- a/pkg/frontend/nvme.go
+++ b/pkg/frontend/nvme.go
@@ -103,7 +103,7 @@ func (s *Server) CreateNVMeSubsystem(_ context.Context, in *pb.CreateNVMeSubsyst
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeSubsystemId, in.NvMeSubsystem.Spec.Id.Value)
 		name = in.NvMeSubsystemId
 	}
-	in.NvMeSubsystem.Spec.Id.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
+	in.NvMeSubsystem.Spec.Id.Value = name
 	// idempotent API when called with same key, should return same object
 	subsys, ok := s.Nvme.Subsystems[in.NvMeSubsystem.Spec.Id.Value]
 	if ok {
@@ -267,7 +267,7 @@ func (s *Server) CreateNVMeController(_ context.Context, in *pb.CreateNVMeContro
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeControllerId, in.NvMeController.Spec.Id.Value)
 		name = in.NvMeControllerId
 	}
-	in.NvMeController.Spec.Id.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
+	in.NvMeController.Spec.Id.Value = name
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.Nvme.Controllers[in.NvMeController.Spec.Id.Value]
 	if ok {
@@ -397,7 +397,7 @@ func (s *Server) CreateNVMeNamespace(_ context.Context, in *pb.CreateNVMeNamespa
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeNamespaceId, in.NvMeNamespace.Spec.Id.Value)
 		name = in.NvMeNamespaceId
 	}
-	in.NvMeNamespace.Spec.Id.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
+	in.NvMeNamespace.Spec.Id.Value = name
 	// idempotent API when called with same key, should return same object
 	namespace, ok := s.Nvme.Namespaces[in.NvMeNamespace.Spec.Id.Value]
 	if ok {

--- a/pkg/frontend/nvme.go
+++ b/pkg/frontend/nvme.go
@@ -98,9 +98,12 @@ func (c *tcpSubsystemListener) Params(_ *pb.NVMeController, nqn string) spdk.Nvm
 func (s *Server) CreateNVMeSubsystem(_ context.Context, in *pb.CreateNVMeSubsystemRequest) (*pb.NVMeSubsystem, error) {
 	log.Printf("CreateNVMeSubsystem: Received from client: %v", in)
 	// see https://google.aip.dev/133#user-specified-ids
+	name := uuid.New().String()
 	if in.NvMeSubsystemId != "" {
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeSubsystemId, in.NvMeSubsystem.Spec.Id.Value)
+		name = in.NvMeSubsystemId
 	}
+	in.NvMeSubsystem.Spec.Id.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
 	// idempotent API when called with same key, should return same object
 	subsys, ok := s.Nvme.Subsystems[in.NvMeSubsystem.Spec.Id.Value]
 	if ok {
@@ -259,9 +262,12 @@ func (s *Server) NVMeSubsystemStats(_ context.Context, in *pb.NVMeSubsystemStats
 func (s *Server) CreateNVMeController(_ context.Context, in *pb.CreateNVMeControllerRequest) (*pb.NVMeController, error) {
 	log.Printf("Received from client: %v", in.NvMeController)
 	// see https://google.aip.dev/133#user-specified-ids
+	name := uuid.New().String()
 	if in.NvMeControllerId != "" {
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeControllerId, in.NvMeController.Spec.Id.Value)
+		name = in.NvMeControllerId
 	}
+	in.NvMeController.Spec.Id.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.Nvme.Controllers[in.NvMeController.Spec.Id.Value]
 	if ok {
@@ -386,9 +392,12 @@ func (s *Server) NVMeControllerStats(_ context.Context, in *pb.NVMeControllerSta
 func (s *Server) CreateNVMeNamespace(_ context.Context, in *pb.CreateNVMeNamespaceRequest) (*pb.NVMeNamespace, error) {
 	log.Printf("CreateNVMeNamespace: Received from client: %v", in)
 	// see https://google.aip.dev/133#user-specified-ids
+	name := uuid.New().String()
 	if in.NvMeNamespaceId != "" {
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeNamespaceId, in.NvMeNamespace.Spec.Id.Value)
+		name = in.NvMeNamespaceId
 	}
+	in.NvMeNamespace.Spec.Id.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
 	// idempotent API when called with same key, should return same object
 	namespace, ok := s.Nvme.Namespaces[in.NvMeNamespace.Spec.Id.Value]
 	if ok {

--- a/pkg/frontend/nvme_test.go
+++ b/pkg/frontend/nvme_test.go
@@ -167,7 +167,7 @@ func TestFrontEnd_CreateNVMeSubsystem(t *testing.T) {
 				testEnv.opiSpdkServer.Nvme.Subsystems[testSubsystem.Spec.Id.Value] = &testSubsystem
 			}
 
-			request := &pb.CreateNVMeSubsystemRequest{NvMeSubsystem: tt.in}
+			request := &pb.CreateNVMeSubsystemRequest{NvMeSubsystem: tt.in, NvMeSubsystemId: "subsystem-test"}
 			response, err := testEnv.client.CreateNVMeSubsystem(testEnv.ctx, request)
 			if response != nil {
 				mtt, _ := proto.Marshal(tt.out)
@@ -730,7 +730,7 @@ func TestFrontEnd_CreateNVMeController(t *testing.T) {
 				testEnv.opiSpdkServer.Nvme.Controllers[testController.Spec.Id.Value] = &testController
 			}
 
-			request := &pb.CreateNVMeControllerRequest{NvMeController: tt.in}
+			request := &pb.CreateNVMeControllerRequest{NvMeController: tt.in, NvMeControllerId: "controller-test"}
 			response, err := testEnv.client.CreateNVMeController(testEnv.ctx, request)
 			if response != nil {
 				mtt, _ := proto.Marshal(tt.out)
@@ -1141,7 +1141,7 @@ func TestFrontEnd_CreateNVMeNamespace(t *testing.T) {
 				testEnv.opiSpdkServer.Nvme.Namespaces[testNamespace.Spec.Id.Value] = &testNamespace
 			}
 
-			request := &pb.CreateNVMeNamespaceRequest{NvMeNamespace: tt.in}
+			request := &pb.CreateNVMeNamespaceRequest{NvMeNamespace: tt.in, NvMeNamespaceId: "namespace-test"}
 			response, err := testEnv.client.CreateNVMeNamespace(testEnv.ctx, request)
 			if response != nil {
 				mtt, _ := proto.Marshal(tt.out)

--- a/pkg/frontend/scsi.go
+++ b/pkg/frontend/scsi.go
@@ -33,9 +33,12 @@ func sortScsiControllers(controllers []*pb.VirtioScsiController) {
 func (s *Server) CreateVirtioScsiController(_ context.Context, in *pb.CreateVirtioScsiControllerRequest) (*pb.VirtioScsiController, error) {
 	log.Printf("CreateVirtioScsiController: Received from client: %v", in)
 	// see https://google.aip.dev/133#user-specified-ids
+	name := uuid.New().String()
 	if in.VirtioScsiControllerId != "" {
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioScsiControllerId, in.VirtioScsiController.Id.Value)
+		name = in.VirtioScsiControllerId
 	}
+	in.VirtioScsiController.Id.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.Virt.ScsiCtrls[in.VirtioScsiController.Id.Value]
 	if ok {
@@ -164,9 +167,12 @@ func (s *Server) VirtioScsiControllerStats(_ context.Context, in *pb.VirtioScsiC
 func (s *Server) CreateVirtioScsiLun(_ context.Context, in *pb.CreateVirtioScsiLunRequest) (*pb.VirtioScsiLun, error) {
 	log.Printf("CreateVirtioScsiLun: Received from client: %v", in)
 	// see https://google.aip.dev/133#user-specified-ids
+	name := uuid.New().String()
 	if in.VirtioScsiLunId != "" {
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioScsiLunId, in.VirtioScsiLun.Id.Value)
+		name = in.VirtioScsiLunId
 	}
+	in.VirtioScsiLun.Id.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
 	// idempotent API when called with same key, should return same object
 	lun, ok := s.Virt.ScsiLuns[in.VirtioScsiLun.Id.Value]
 	if ok {

--- a/pkg/frontend/scsi.go
+++ b/pkg/frontend/scsi.go
@@ -38,7 +38,7 @@ func (s *Server) CreateVirtioScsiController(_ context.Context, in *pb.CreateVirt
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioScsiControllerId, in.VirtioScsiController.Id.Value)
 		name = in.VirtioScsiControllerId
 	}
-	in.VirtioScsiController.Id.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
+	in.VirtioScsiController.Id.Value = name
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.Virt.ScsiCtrls[in.VirtioScsiController.Id.Value]
 	if ok {
@@ -172,7 +172,7 @@ func (s *Server) CreateVirtioScsiLun(_ context.Context, in *pb.CreateVirtioScsiL
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioScsiLunId, in.VirtioScsiLun.Id.Value)
 		name = in.VirtioScsiLunId
 	}
-	in.VirtioScsiLun.Id.Value = fmt.Sprintf("//storage.opiproject.org/volumes/%s", name)
+	in.VirtioScsiLun.Id.Value = name
 	// idempotent API when called with same key, should return same object
 	lun, ok := s.Virt.ScsiLuns[in.VirtioScsiLun.Id.Value]
 	if ok {

--- a/pkg/kvm/blk_test.go
+++ b/pkg/kvm/blk_test.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	testVirtioBlkID            = "virtio-blk-42"
-	testCreateVirtioBlkRequest = &pb.CreateVirtioBlkRequest{VirtioBlk: &pb.VirtioBlk{
+	testCreateVirtioBlkRequest = &pb.CreateVirtioBlkRequest{VirtioBlkId: testVirtioBlkID, VirtioBlk: &pb.VirtioBlk{
 		Id:       &pc.ObjectKey{Value: testVirtioBlkID},
 		PcieId:   &pb.PciEndpoint{PhysicalFunction: 42},
 		VolumeId: &pc.ObjectKey{Value: "Malloc42"},

--- a/pkg/kvm/nvme_test.go
+++ b/pkg/kvm/nvme_test.go
@@ -30,7 +30,7 @@ var (
 			Nqn: "nqn.2022-09.io.spdk:opi2",
 		},
 	}
-	testCreateNvmeControllerRequest = &pb.CreateNVMeControllerRequest{NvMeController: &pb.NVMeController{
+	testCreateNvmeControllerRequest = &pb.CreateNVMeControllerRequest{NvMeControllerId: testNvmeControllerID, NvMeController: &pb.NVMeController{
 		Spec: &pb.NVMeControllerSpec{
 			Id:               &pc.ObjectKey{Value: testNvmeControllerID},
 			SubsystemId:      testSubsystem.Spec.Id,

--- a/pkg/middleend/encryption_test.go
+++ b/pkg/middleend/encryption_test.go
@@ -225,7 +225,7 @@ func TestMiddleEnd_CreateEncryptedVolume(t *testing.T) {
 			testEnv := createTestEnvironment(tt.start, tt.spdk)
 			defer testEnv.Close()
 
-			request := &pb.CreateEncryptedVolumeRequest{EncryptedVolume: tt.in}
+			request := &pb.CreateEncryptedVolumeRequest{EncryptedVolume: tt.in, EncryptedVolumeId: "mytest"}
 			response, err := testEnv.client.CreateEncryptedVolume(testEnv.ctx, request)
 			if response != nil {
 				if string(response.Key) != string(tt.out.Key) &&

--- a/pkg/middleend/qos_test.go
+++ b/pkg/middleend/qos_test.go
@@ -263,7 +263,7 @@ func TestMiddleEnd_CreateQosVolume(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			testEnv := createTestEnvironment(tt.start, tt.spdk)
 			defer testEnv.Close()
-			request := &pb.CreateQosVolumeRequest{QosVolume: tt.in}
+			request := &pb.CreateQosVolumeRequest{QosVolume: tt.in, QosVolumeId: "mytest"}
 			if tt.existBefore {
 				testEnv.opiSpdkServer.volumes.qosVolumes[tt.in.QosVolumeId.Value] = tt.in
 			}

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -45,9 +45,9 @@ grpc_cli=(docker run --network=opi-spdk-bridge_opi --rm docker.io/namely/grpc-cl
 "${grpc_cli[@]}" ls opi-spdk-server:50051 opi_api.storage.v1.NullDebugService -l
 
 # test nvme
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNVMeSubsystem "{nv_me_subsystem : {spec : {id : {value : 'subsystem1'}, nqn: 'nqn.2022-09.io.spdk:opitest1', serial_number: 'myserial1', model_number: 'mymodel1', max_namespaces: 11} } }"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNVMeController "{nv_me_controller : {spec : {id : {value : 'controller1'}, nvme_controller_id: 2, subsystem_id : { value : 'subsystem1' }, pcie_id : {physical_function : 0}, max_nsq:5, max_ncq:5 } } }"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNVMeNamespace "{'nv_me_namespace' : { 'spec' : {'id' : {'value' : 'namespace1'}, 'subsystem_id' : { 'value' : 'subsystem1' }, 'volume_id' : { 'value' : 'Malloc1' }, 'host_nsid' : '1' } } }"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNVMeSubsystem "{nv_me_subsystem_id: 'subsystem1', nv_me_subsystem : {spec : {id : {value : 'subsystem1'}, nqn: 'nqn.2022-09.io.spdk:opitest1', serial_number: 'myserial1', model_number: 'mymodel1', max_namespaces: 11} } }"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNVMeController "{nv_me_controller_id: 'controller1', nv_me_controller : {spec : {id : {value : 'controller1'}, nvme_controller_id: 2, subsystem_id : { value : 'subsystem1' }, pcie_id : {physical_function : 0}, max_nsq:5, max_ncq:5 } } }"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNVMeNamespace "{nv_me_namespace_id: 'namespace1', 'nv_me_namespace' : { 'spec' : {'id' : {'value' : 'namespace1'}, 'subsystem_id' : { 'value' : 'subsystem1' }, 'volume_id' : { 'value' : 'Malloc1' }, 'host_nsid' : '1' } } }"
 "${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNVMeSubsystem "{name : 'subsystem1'}"
 "${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNVMeController "{name : 'controller1'}"
 "${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNVMeNamespace "{name :  'namespace1'}"


### PR DESCRIPTION
using this algorithm (discussed in slack):
```
if request.book_id != ""
    request.book.name = "//api.opiproject.org/books/{request.book_id}"
else
    request.book.name = "//api.opiproject.org/books/{generate_new_random_uuid}"
db[request.book.name] = request
return request.book
```

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
