### PR TITLE
tests: do not send id/name/handle value on the create request

### DIFF
--- a/pkg/backend/aio_test.go
+++ b/pkg/backend/aio_test.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	testAioVolume = pb.AioController{
-		Handle:      &pc.ObjectKey{Value: "mytest"},
+		Handle:      &pc.ObjectKey{},
 		BlockSize:   512,
 		BlocksCount: 12,
 		Filename:    "/tmp/aio_bdev_file",
@@ -44,7 +44,7 @@ func TestBackEnd_CreateAioController(t *testing.T) {
 			nil,
 			[]string{`{"id":%d,"error":{"code":0,"message":""},"result":""}`},
 			codes.InvalidArgument,
-			fmt.Sprintf("Could not create Aio Dev: %v", testAioVolume.Handle.Value),
+			fmt.Sprintf("Could not create Aio Dev: %v", "mytest"),
 			true,
 			false,
 		},
@@ -102,7 +102,10 @@ func TestBackEnd_CreateAioController(t *testing.T) {
 			defer testEnv.Close()
 
 			if tt.exist {
-				testEnv.opiSpdkServer.Volumes.AioVolumes[testAioVolume.Handle.Value] = &testAioVolume
+				testEnv.opiSpdkServer.Volumes.AioVolumes["mytest"] = &testAioVolume
+			}
+			if tt.out != nil {
+				tt.out.Handle.Value = "mytest"
 			}
 
 			request := &pb.CreateAioControllerRequest{AioController: tt.in, AioControllerId: "mytest"}

--- a/pkg/backend/null_test.go
+++ b/pkg/backend/null_test.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	testNullVolume = pb.NullDebug{
-		Handle:      &pc.ObjectKey{Value: "mytest"},
+		Handle:      &pc.ObjectKey{},
 		BlockSize:   512,
 		BlocksCount: 64,
 	}
@@ -43,7 +43,7 @@ func TestBackEnd_CreateNullDebug(t *testing.T) {
 			nil,
 			[]string{`{"id":%d,"error":{"code":0,"message":""},"result":""}`},
 			codes.InvalidArgument,
-			fmt.Sprintf("Could not create Null Dev: %v", testNullVolume.Handle.Value),
+			fmt.Sprintf("Could not create Null Dev: %v", "mytest"),
 			true,
 			false,
 		},
@@ -101,7 +101,10 @@ func TestBackEnd_CreateNullDebug(t *testing.T) {
 			defer testEnv.Close()
 
 			if tt.exist {
-				testEnv.opiSpdkServer.Volumes.NullVolumes[testNullVolume.Handle.Value] = &testNullVolume
+				testEnv.opiSpdkServer.Volumes.NullVolumes["mytest"] = &testNullVolume
+			}
+			if tt.out != nil {
+				tt.out.Handle.Value = "mytest"
 			}
 
 			request := &pb.CreateNullDebugRequest{NullDebug: tt.in, NullDebugId: "mytest"}

--- a/pkg/backend/nvme_test.go
+++ b/pkg/backend/nvme_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestBackEnd_CreateNVMfRemoteController(t *testing.T) {
 	controller := &pb.NVMfRemoteController{
-		Id:      &pc.ObjectKey{Value: "OpiNvme8"},
+		Id:      &pc.ObjectKey{},
 		Trtype:  pb.NvmeTransportType_NVME_TRANSPORT_TCP,
 		Adrfam:  pb.NvmeAddressFamily_NVMF_ADRFAM_IPV4,
 		Traddr:  "127.0.0.1",
@@ -103,7 +103,10 @@ func TestBackEnd_CreateNVMfRemoteController(t *testing.T) {
 			defer testEnv.Close()
 
 			if tt.exist {
-				testEnv.opiSpdkServer.Volumes.NvmeVolumes[controller.Id.Value] = controller
+				testEnv.opiSpdkServer.Volumes.NvmeVolumes["OpiNvme8"] = controller
+			}
+			if tt.out != nil {
+				tt.out.Id.Value = "OpiNvme8"
 			}
 
 			request := &pb.CreateNVMfRemoteControllerRequest{NvMfRemoteController: tt.in, NvMfRemoteControllerId: "OpiNvme8"}

--- a/pkg/frontend/blk_test.go
+++ b/pkg/frontend/blk_test.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	testVirtioCtrl = pb.VirtioBlk{
-		Id:       &pc.ObjectKey{Value: "virtio-blk-42"},
+		Id:       &pc.ObjectKey{},
 		PcieId:   &pb.PciEndpoint{PhysicalFunction: 42},
 		VolumeId: &pc.ObjectKey{Value: "Malloc42"},
 		MaxIoQps: 1,
@@ -62,6 +62,10 @@ func TestFrontEnd_CreateVirtioBlk(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			testEnv := createTestEnvironment(true, test.spdk)
 			defer testEnv.Close()
+
+			if test.out != nil {
+				test.out.Id.Value = "virtio-blk-42"
+			}
 
 			request := &pb.CreateVirtioBlkRequest{VirtioBlk: test.in, VirtioBlkId: "virtio-blk-42"}
 			response, err := testEnv.client.CreateVirtioBlk(testEnv.ctx, request)

--- a/pkg/frontend/nvme_test.go
+++ b/pkg/frontend/nvme_test.go
@@ -25,14 +25,14 @@ import (
 var (
 	testSubsystem = pb.NVMeSubsystem{
 		Spec: &pb.NVMeSubsystemSpec{
-			Id:  &pc.ObjectKey{Value: "subsystem-test"},
+			Id:  &pc.ObjectKey{},
 			Nqn: "nqn.2022-09.io.spdk:opi3",
 		},
 	}
 
 	testController = pb.NVMeController{
 		Spec: &pb.NVMeControllerSpec{
-			Id:               &pc.ObjectKey{Value: "controller-test"},
+			Id:               &pc.ObjectKey{},
 			SubsystemId:      &pc.ObjectKey{Value: "subsystem-test"},
 			PcieId:           &pb.PciEndpoint{PhysicalFunction: 1, VirtualFunction: 2},
 			NvmeControllerId: 17,
@@ -44,7 +44,7 @@ var (
 
 	testNamespace = pb.NVMeNamespace{
 		Spec: &pb.NVMeNamespaceSpec{
-			Id:          &pc.ObjectKey{Value: "namespace-test"},
+			Id:          &pc.ObjectKey{},
 			HostNsid:    22,
 			SubsystemId: testSubsystem.Spec.Id,
 		},
@@ -57,7 +57,7 @@ var (
 
 func TestFrontEnd_CreateNVMeSubsystem(t *testing.T) {
 	spec := &pb.NVMeSubsystemSpec{
-		Id:           &pc.ObjectKey{Value: "subsystem-test"},
+		Id:           &pc.ObjectKey{},
 		Nqn:          "nqn.2022-09.io.spdk:opi3",
 		SerialNumber: "OpiSerialNumber",
 		ModelNumber:  "OpiModelNumber",
@@ -164,7 +164,10 @@ func TestFrontEnd_CreateNVMeSubsystem(t *testing.T) {
 			testEnv.opiSpdkServer.Nvme.Controllers[testController.Spec.Id.Value] = &testController
 			testEnv.opiSpdkServer.Nvme.Namespaces[testNamespace.Spec.Id.Value] = &testNamespace
 			if tt.exist {
-				testEnv.opiSpdkServer.Nvme.Subsystems[testSubsystem.Spec.Id.Value] = &testSubsystem
+				testEnv.opiSpdkServer.Nvme.Subsystems["subsystem-test"] = &testSubsystem
+			}
+			if tt.out != nil {
+				tt.out.Spec.Id.Value = "subsystem-test"
 			}
 
 			request := &pb.CreateNVMeSubsystemRequest{NvMeSubsystem: tt.in, NvMeSubsystemId: "subsystem-test"}
@@ -613,7 +616,7 @@ func TestFrontEnd_CreateNVMeController(t *testing.T) {
 		"valid request with invalid SPDK response": {
 			&pb.NVMeController{
 				Spec: &pb.NVMeControllerSpec{
-					Id:               &pc.ObjectKey{Value: "controller-test"},
+					Id:               &pc.ObjectKey{},
 					SubsystemId:      &pc.ObjectKey{Value: "subsystem-test"},
 					PcieId:           &pb.PciEndpoint{PhysicalFunction: 1, VirtualFunction: 2},
 					NvmeControllerId: 1,
@@ -629,7 +632,7 @@ func TestFrontEnd_CreateNVMeController(t *testing.T) {
 		"valid request with empty SPDK response": {
 			&pb.NVMeController{
 				Spec: &pb.NVMeControllerSpec{
-					Id:               &pc.ObjectKey{Value: "controller-test"},
+					Id:               &pc.ObjectKey{},
 					SubsystemId:      &pc.ObjectKey{Value: "subsystem-test"},
 					PcieId:           &pb.PciEndpoint{PhysicalFunction: 1, VirtualFunction: 2},
 					NvmeControllerId: 1,
@@ -645,7 +648,7 @@ func TestFrontEnd_CreateNVMeController(t *testing.T) {
 		"valid request with ID mismatch SPDK response": {
 			&pb.NVMeController{
 				Spec: &pb.NVMeControllerSpec{
-					Id:               &pc.ObjectKey{Value: "controller-test"},
+					Id:               &pc.ObjectKey{},
 					SubsystemId:      &pc.ObjectKey{Value: "subsystem-test"},
 					PcieId:           &pb.PciEndpoint{PhysicalFunction: 1, VirtualFunction: 2},
 					NvmeControllerId: 1,
@@ -661,7 +664,7 @@ func TestFrontEnd_CreateNVMeController(t *testing.T) {
 		"valid request with error code from SPDK response": {
 			&pb.NVMeController{
 				Spec: &pb.NVMeControllerSpec{
-					Id:               &pc.ObjectKey{Value: "controller-test"},
+					Id:               &pc.ObjectKey{},
 					SubsystemId:      &pc.ObjectKey{Value: "subsystem-test"},
 					PcieId:           &pb.PciEndpoint{PhysicalFunction: 1, VirtualFunction: 2},
 					NvmeControllerId: 1,
@@ -677,7 +680,7 @@ func TestFrontEnd_CreateNVMeController(t *testing.T) {
 		"valid request with valid SPDK response": {
 			&pb.NVMeController{
 				Spec: &pb.NVMeControllerSpec{
-					Id:               &pc.ObjectKey{Value: "controller-test"},
+					Id:               &pc.ObjectKey{},
 					SubsystemId:      &pc.ObjectKey{Value: "subsystem-test"},
 					PcieId:           &pb.PciEndpoint{PhysicalFunction: 1, VirtualFunction: 2},
 					NvmeControllerId: 17,
@@ -703,7 +706,7 @@ func TestFrontEnd_CreateNVMeController(t *testing.T) {
 		"already exists": {
 			&pb.NVMeController{
 				Spec: &pb.NVMeControllerSpec{
-					Id:               &pc.ObjectKey{Value: "controller-test"},
+					Id:               &pc.ObjectKey{},
 					SubsystemId:      &pc.ObjectKey{Value: "subsystem-test"},
 					PcieId:           &pb.PciEndpoint{PhysicalFunction: 1, VirtualFunction: 2},
 					NvmeControllerId: 17,
@@ -727,7 +730,10 @@ func TestFrontEnd_CreateNVMeController(t *testing.T) {
 			testEnv.opiSpdkServer.Nvme.Subsystems[testSubsystem.Spec.Id.Value] = &testSubsystem
 			testEnv.opiSpdkServer.Nvme.Namespaces[testNamespace.Spec.Id.Value] = &testNamespace
 			if tt.exist {
-				testEnv.opiSpdkServer.Nvme.Controllers[testController.Spec.Id.Value] = &testController
+				testEnv.opiSpdkServer.Nvme.Controllers["controller-test"] = &testController
+			}
+			if tt.out != nil {
+				tt.out.Spec.Id.Value = "controller-test"
 			}
 
 			request := &pb.CreateNVMeControllerRequest{NvMeController: tt.in, NvMeControllerId: "controller-test"}
@@ -1029,7 +1035,7 @@ func TestFrontEnd_NVMeControllerStats(t *testing.T) {
 
 func TestFrontEnd_CreateNVMeNamespace(t *testing.T) {
 	spec := &pb.NVMeNamespaceSpec{
-		Id:          &pc.ObjectKey{Value: "namespace-test"},
+		Id:          &pc.ObjectKey{},
 		SubsystemId: &pc.ObjectKey{Value: "subsystem-test"},
 		HostNsid:    0,
 		VolumeId:    &pc.ObjectKey{Value: "Malloc1"},
@@ -1038,7 +1044,7 @@ func TestFrontEnd_CreateNVMeNamespace(t *testing.T) {
 		Eui64:       1967554867335598546,
 	}
 	namespaceSpec := &pb.NVMeNamespaceSpec{
-		Id:          &pc.ObjectKey{Value: "namespace-test"},
+		Id:          &pc.ObjectKey{},
 		SubsystemId: &pc.ObjectKey{Value: "subsystem-test"},
 		HostNsid:    22,
 		VolumeId:    &pc.ObjectKey{Value: "Malloc1"},
@@ -1138,7 +1144,10 @@ func TestFrontEnd_CreateNVMeNamespace(t *testing.T) {
 			testEnv.opiSpdkServer.Nvme.Subsystems[testSubsystem.Spec.Id.Value] = &testSubsystem
 			testEnv.opiSpdkServer.Nvme.Controllers[testController.Spec.Id.Value] = &testController
 			if tt.exist {
-				testEnv.opiSpdkServer.Nvme.Namespaces[testNamespace.Spec.Id.Value] = &testNamespace
+				testEnv.opiSpdkServer.Nvme.Namespaces["namespace-test"] = &testNamespace
+			}
+			if tt.out != nil {
+				tt.out.Spec.Id.Value = "namespace-test"
 			}
 
 			request := &pb.CreateNVMeNamespaceRequest{NvMeNamespace: tt.in, NvMeNamespaceId: "namespace-test"}

--- a/pkg/kvm/blk_test.go
+++ b/pkg/kvm/blk_test.go
@@ -22,7 +22,7 @@ import (
 var (
 	testVirtioBlkID            = "virtio-blk-42"
 	testCreateVirtioBlkRequest = &pb.CreateVirtioBlkRequest{VirtioBlkId: testVirtioBlkID, VirtioBlk: &pb.VirtioBlk{
-		Id:       &pc.ObjectKey{Value: testVirtioBlkID},
+		Id:       &pc.ObjectKey{},
 		PcieId:   &pb.PciEndpoint{PhysicalFunction: 42},
 		VolumeId: &pc.ObjectKey{Value: "Malloc42"},
 		MaxIoQps: 1,

--- a/pkg/kvm/nvme_test.go
+++ b/pkg/kvm/nvme_test.go
@@ -26,7 +26,7 @@ var (
 	testNvmeControllerID = "nvme-43"
 	testSubsystem        = pb.NVMeSubsystem{
 		Spec: &pb.NVMeSubsystemSpec{
-			Id:  &pc.ObjectKey{Value: "subsystem-test"},
+			Id:  &pc.ObjectKey{},
 			Nqn: "nqn.2022-09.io.spdk:opi2",
 		},
 	}


### PR DESCRIPTION
id/name/handle field is filled by the server instead
one can specify {resource}_id field instead

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
