### PR TITLE
tests: do not send id/name/handle OBJECT on the create request

### DIFF
--- a/pkg/backend/aio.go
+++ b/pkg/backend/aio.go
@@ -35,10 +35,10 @@ func (s *Server) CreateAioController(_ context.Context, in *pb.CreateAioControll
 	// see https://google.aip.dev/133#user-specified-ids
 	name := uuid.New().String()
 	if in.AioControllerId != "" {
-		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.AioControllerId, in.AioController.Handle.Value)
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.AioControllerId, in.AioController.Handle)
 		name = in.AioControllerId
 	}
-	in.AioController.Handle.Value = name
+	in.AioController.Handle = &pc.ObjectKey{Value: name}
 	// idempotent API when called with same key, should return same object
 	volume, ok := s.Volumes.AioVolumes[in.AioController.Handle.Value]
 	if ok {

--- a/pkg/backend/aio_test.go
+++ b/pkg/backend/aio_test.go
@@ -22,7 +22,6 @@ import (
 
 var (
 	testAioVolume = pb.AioController{
-		Handle:      &pc.ObjectKey{},
 		BlockSize:   512,
 		BlocksCount: 12,
 		Filename:    "/tmp/aio_bdev_file",
@@ -105,7 +104,7 @@ func TestBackEnd_CreateAioController(t *testing.T) {
 				testEnv.opiSpdkServer.Volumes.AioVolumes["mytest"] = &testAioVolume
 			}
 			if tt.out != nil {
-				tt.out.Handle.Value = "mytest"
+				tt.out.Handle = &pc.ObjectKey{Value: "mytest"}
 			}
 
 			request := &pb.CreateAioControllerRequest{AioController: tt.in, AioControllerId: "mytest"}
@@ -711,7 +710,7 @@ func TestBackEnd_DeleteAioController(t *testing.T) {
 			testEnv := createTestEnvironment(tt.start, tt.spdk)
 			defer testEnv.Close()
 
-			testEnv.opiSpdkServer.Volumes.AioVolumes[testAioVolume.Handle.Value] = &testAioVolume
+			testEnv.opiSpdkServer.Volumes.AioVolumes["mytest"] = &testAioVolume
 
 			request := &pb.DeleteAioControllerRequest{Name: tt.in, AllowMissing: tt.missing}
 			response, err := testEnv.client.DeleteAioController(testEnv.ctx, request)

--- a/pkg/backend/null.go
+++ b/pkg/backend/null.go
@@ -35,10 +35,10 @@ func (s *Server) CreateNullDebug(_ context.Context, in *pb.CreateNullDebugReques
 	// see https://google.aip.dev/133#user-specified-ids
 	name := uuid.New().String()
 	if in.NullDebugId != "" {
-		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NullDebugId, in.NullDebug.Handle.Value)
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NullDebugId, in.NullDebug.Handle)
 		name = in.NullDebugId
 	}
-	in.NullDebug.Handle.Value = name
+	in.NullDebug.Handle = &pc.ObjectKey{Value: name}
 	// idempotent API when called with same key, should return same object
 	volume, ok := s.Volumes.NullVolumes[in.NullDebug.Handle.Value]
 	if ok {

--- a/pkg/backend/null_test.go
+++ b/pkg/backend/null_test.go
@@ -22,7 +22,6 @@ import (
 
 var (
 	testNullVolume = pb.NullDebug{
-		Handle:      &pc.ObjectKey{},
 		BlockSize:   512,
 		BlocksCount: 64,
 	}
@@ -104,7 +103,7 @@ func TestBackEnd_CreateNullDebug(t *testing.T) {
 				testEnv.opiSpdkServer.Volumes.NullVolumes["mytest"] = &testNullVolume
 			}
 			if tt.out != nil {
-				tt.out.Handle.Value = "mytest"
+				tt.out.Handle = &pc.ObjectKey{Value: "mytest"}
 			}
 
 			request := &pb.CreateNullDebugRequest{NullDebug: tt.in, NullDebugId: "mytest"}
@@ -721,7 +720,7 @@ func TestBackEnd_DeleteNullDebug(t *testing.T) {
 			testEnv := createTestEnvironment(tt.start, tt.spdk)
 			defer testEnv.Close()
 
-			testEnv.opiSpdkServer.Volumes.NullVolumes[testNullVolume.Handle.Value] = &testNullVolume
+			testEnv.opiSpdkServer.Volumes.NullVolumes["mytest"] = &testNullVolume
 
 			request := &pb.DeleteNullDebugRequest{Name: tt.in, AllowMissing: tt.missing}
 			response, err := testEnv.client.DeleteNullDebug(testEnv.ctx, request)

--- a/pkg/backend/nvme.go
+++ b/pkg/backend/nvme.go
@@ -36,10 +36,10 @@ func (s *Server) CreateNVMfRemoteController(_ context.Context, in *pb.CreateNVMf
 	// see https://google.aip.dev/133#user-specified-ids
 	name := uuid.New().String()
 	if in.NvMfRemoteControllerId != "" {
-		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMfRemoteControllerId, in.NvMfRemoteController.Id.Value)
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMfRemoteControllerId, in.NvMfRemoteController.Id)
 		name = in.NvMfRemoteControllerId
 	}
-	in.NvMfRemoteController.Id.Value = name
+	in.NvMfRemoteController.Id = &pc.ObjectKey{Value: name}
 	// idempotent API when called with same key, should return same object
 	volume, ok := s.Volumes.NvmeVolumes[in.NvMfRemoteController.Id.Value]
 	if ok {

--- a/pkg/backend/nvme_test.go
+++ b/pkg/backend/nvme_test.go
@@ -23,7 +23,6 @@ import (
 
 func TestBackEnd_CreateNVMfRemoteController(t *testing.T) {
 	controller := &pb.NVMfRemoteController{
-		Id:      &pc.ObjectKey{},
 		Trtype:  pb.NvmeTransportType_NVME_TRANSPORT_TCP,
 		Adrfam:  pb.NvmeAddressFamily_NVMF_ADRFAM_IPV4,
 		Traddr:  "127.0.0.1",
@@ -106,7 +105,7 @@ func TestBackEnd_CreateNVMfRemoteController(t *testing.T) {
 				testEnv.opiSpdkServer.Volumes.NvmeVolumes["OpiNvme8"] = controller
 			}
 			if tt.out != nil {
-				tt.out.Id.Value = "OpiNvme8"
+				tt.out.Id = &pc.ObjectKey{Value: "OpiNvme8"}
 			}
 
 			request := &pb.CreateNVMfRemoteControllerRequest{NvMfRemoteController: tt.in, NvMfRemoteControllerId: "OpiNvme8"}

--- a/pkg/frontend/blk.go
+++ b/pkg/frontend/blk.go
@@ -35,10 +35,10 @@ func (s *Server) CreateVirtioBlk(_ context.Context, in *pb.CreateVirtioBlkReques
 	// see https://google.aip.dev/133#user-specified-ids
 	name := uuid.New().String()
 	if in.VirtioBlkId != "" {
-		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioBlkId, in.VirtioBlk.Id.Value)
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioBlkId, in.VirtioBlk.Id)
 		name = in.VirtioBlkId
 	}
-	in.VirtioBlk.Id.Value = name
+	in.VirtioBlk.Id = &pc.ObjectKey{Value: name}
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.Virt.BlkCtrls[in.VirtioBlk.Id.Value]
 	if ok {

--- a/pkg/frontend/blk_test.go
+++ b/pkg/frontend/blk_test.go
@@ -24,7 +24,6 @@ import (
 
 var (
 	testVirtioCtrl = pb.VirtioBlk{
-		Id:       &pc.ObjectKey{},
 		PcieId:   &pb.PciEndpoint{PhysicalFunction: 42},
 		VolumeId: &pc.ObjectKey{Value: "Malloc42"},
 		MaxIoQps: 1,
@@ -64,7 +63,7 @@ func TestFrontEnd_CreateVirtioBlk(t *testing.T) {
 			defer testEnv.Close()
 
 			if test.out != nil {
-				test.out.Id.Value = "virtio-blk-42"
+				test.out.Id = &pc.ObjectKey{Value: "virtio-blk-42"}
 			}
 
 			request := &pb.CreateVirtioBlkRequest{VirtioBlk: test.in, VirtioBlkId: "virtio-blk-42"}
@@ -395,7 +394,7 @@ func TestFrontEnd_GetVirtioBlk(t *testing.T) {
 			testEnv := createTestEnvironment(tt.start, tt.spdk)
 			defer testEnv.Close()
 
-			testEnv.opiSpdkServer.Virt.BlkCtrls[testVirtioCtrl.Id.Value] = &testVirtioCtrl
+			testEnv.opiSpdkServer.Virt.BlkCtrls["virtio-blk-42"] = &testVirtioCtrl
 
 			request := &pb.GetVirtioBlkRequest{Name: tt.in}
 			response, err := testEnv.client.GetVirtioBlk(testEnv.ctx, request)
@@ -446,7 +445,7 @@ func TestFrontEnd_VirtioBlkStats(t *testing.T) {
 			testEnv := createTestEnvironment(tt.start, tt.spdk)
 			defer testEnv.Close()
 
-			testEnv.opiSpdkServer.Virt.BlkCtrls[testVirtioCtrl.Id.Value] = &testVirtioCtrl
+			testEnv.opiSpdkServer.Virt.BlkCtrls["virtio-blk-42"] = &testVirtioCtrl
 
 			request := &pb.VirtioBlkStatsRequest{ControllerId: &pc.ObjectKey{Value: tt.in}}
 			response, err := testEnv.client.VirtioBlkStats(testEnv.ctx, request)
@@ -549,7 +548,7 @@ func TestFrontEnd_DeleteVirtioBlk(t *testing.T) {
 			testEnv := createTestEnvironment(tt.start, tt.spdk)
 			defer testEnv.Close()
 
-			testEnv.opiSpdkServer.Virt.BlkCtrls[testVirtioCtrl.Id.Value] = &testVirtioCtrl
+			testEnv.opiSpdkServer.Virt.BlkCtrls["virtio-blk-42"] = &testVirtioCtrl
 
 			request := &pb.DeleteVirtioBlkRequest{Name: tt.in, AllowMissing: tt.missing}
 			response, err := testEnv.client.DeleteVirtioBlk(testEnv.ctx, request)

--- a/pkg/frontend/nvme.go
+++ b/pkg/frontend/nvme.go
@@ -100,10 +100,10 @@ func (s *Server) CreateNVMeSubsystem(_ context.Context, in *pb.CreateNVMeSubsyst
 	// see https://google.aip.dev/133#user-specified-ids
 	name := uuid.New().String()
 	if in.NvMeSubsystemId != "" {
-		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeSubsystemId, in.NvMeSubsystem.Spec.Id.Value)
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeSubsystemId, in.NvMeSubsystem.Spec.Id)
 		name = in.NvMeSubsystemId
 	}
-	in.NvMeSubsystem.Spec.Id.Value = name
+	in.NvMeSubsystem.Spec.Id = &pc.ObjectKey{Value: name}
 	// idempotent API when called with same key, should return same object
 	subsys, ok := s.Nvme.Subsystems[in.NvMeSubsystem.Spec.Id.Value]
 	if ok {
@@ -264,10 +264,10 @@ func (s *Server) CreateNVMeController(_ context.Context, in *pb.CreateNVMeContro
 	// see https://google.aip.dev/133#user-specified-ids
 	name := uuid.New().String()
 	if in.NvMeControllerId != "" {
-		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeControllerId, in.NvMeController.Spec.Id.Value)
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeControllerId, in.NvMeController.Spec.Id)
 		name = in.NvMeControllerId
 	}
-	in.NvMeController.Spec.Id.Value = name
+	in.NvMeController.Spec.Id = &pc.ObjectKey{Value: name}
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.Nvme.Controllers[in.NvMeController.Spec.Id.Value]
 	if ok {
@@ -394,10 +394,10 @@ func (s *Server) CreateNVMeNamespace(_ context.Context, in *pb.CreateNVMeNamespa
 	// see https://google.aip.dev/133#user-specified-ids
 	name := uuid.New().String()
 	if in.NvMeNamespaceId != "" {
-		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeNamespaceId, in.NvMeNamespace.Spec.Id.Value)
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeNamespaceId, in.NvMeNamespace.Spec.Id)
 		name = in.NvMeNamespaceId
 	}
-	in.NvMeNamespace.Spec.Id.Value = name
+	in.NvMeNamespace.Spec.Id = &pc.ObjectKey{Value: name}
 	// idempotent API when called with same key, should return same object
 	namespace, ok := s.Nvme.Namespaces[in.NvMeNamespace.Spec.Id.Value]
 	if ok {

--- a/pkg/frontend/scsi.go
+++ b/pkg/frontend/scsi.go
@@ -35,10 +35,10 @@ func (s *Server) CreateVirtioScsiController(_ context.Context, in *pb.CreateVirt
 	// see https://google.aip.dev/133#user-specified-ids
 	name := uuid.New().String()
 	if in.VirtioScsiControllerId != "" {
-		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioScsiControllerId, in.VirtioScsiController.Id.Value)
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioScsiControllerId, in.VirtioScsiController.Id)
 		name = in.VirtioScsiControllerId
 	}
-	in.VirtioScsiController.Id.Value = name
+	in.VirtioScsiController.Id = &pc.ObjectKey{Value: name}
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.Virt.ScsiCtrls[in.VirtioScsiController.Id.Value]
 	if ok {
@@ -169,10 +169,10 @@ func (s *Server) CreateVirtioScsiLun(_ context.Context, in *pb.CreateVirtioScsiL
 	// see https://google.aip.dev/133#user-specified-ids
 	name := uuid.New().String()
 	if in.VirtioScsiLunId != "" {
-		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioScsiLunId, in.VirtioScsiLun.Id.Value)
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioScsiLunId, in.VirtioScsiLun.Id)
 		name = in.VirtioScsiLunId
 	}
-	in.VirtioScsiLun.Id.Value = name
+	in.VirtioScsiLun.Id = &pc.ObjectKey{Value: name}
 	// idempotent API when called with same key, should return same object
 	lun, ok := s.Virt.ScsiLuns[in.VirtioScsiLun.Id.Value]
 	if ok {

--- a/pkg/kvm/blk_test.go
+++ b/pkg/kvm/blk_test.go
@@ -35,6 +35,7 @@ func TestCreateVirtioBlk(t *testing.T) {
 	if deepcopier.Copy(testCreateVirtioBlkRequest.VirtioBlk).To(expectNotNilOut) != nil {
 		log.Panicf("Failed to copy structure")
 	}
+	expectNotNilOut.Id.Value = testVirtioBlkID
 
 	tests := map[string]struct {
 		jsonRPC              spdk.JSONRPC
@@ -97,7 +98,7 @@ func TestCreateVirtioBlk(t *testing.T) {
 			gotOut, _ := proto.Marshal(out)
 			wantOut, _ := proto.Marshal(test.out)
 			if !bytes.Equal(gotOut, wantOut) {
-				t.Errorf("Expected out %v, got %v", &test.out, out)
+				t.Errorf("Expected out %v, got %v", test.out, out)
 			}
 			if !qmpServer.WereExpectedCallsPerformed() {
 				t.Errorf("Not all expected calls were performed")


### PR DESCRIPTION
previous PR sent empty value, now remove the entire object
id/name/handle field is filled by the server instead
one can specify {resource}_id field instead

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
