### PR TITLE
Adjust KVM create calls to use properly generated names

### DIFF
--- a/pkg/kvm/kvm.go
+++ b/pkg/kvm/kvm.go
@@ -26,6 +26,8 @@ var (
 	errMonitorCreation        = status.Error(codes.Internal, "failed to create QEMU monitor")
 	errAddDeviceFailed        = status.Error(codes.FailedPrecondition, "couldn't add device")
 	errDeviceNotDeleted       = status.Error(codes.FailedPrecondition, "device is not deleted")
+	errNoController           = status.Error(codes.NotFound, "no controller found")
+	errInvalidSubsystem       = status.Error(codes.InvalidArgument, "invalid subsystem")
 	errDevicePartiallyDeleted = status.Error(codes.Internal, "device is partially deleted")
 	errFailedToCreateNvmeDir  = status.Error(codes.FailedPrecondition, "cannot create directory for NVMe controller")
 )
@@ -89,4 +91,9 @@ func isUnixSocketPath(qmpAddress string) bool {
 func isTCPAddress(qmpAddress string) bool {
 	_, _, err := net.SplitHostPort(qmpAddress)
 	return err == nil
+}
+
+func toQemuID(name string) string {
+	// qemu id cannot start with numbers. Add prefix
+	return "opi-" + name
 }

--- a/pkg/kvm/kvm_test.go
+++ b/pkg/kvm/kvm_test.go
@@ -102,7 +102,7 @@ func (s *mockQmpCalls) ExpectAddChardev(id string) *mockQmpCalls {
 		response: `{"return": {"pty": "/tmp/dev/pty/42"}}` + "\n",
 		expectedArgs: []string{
 			`"execute":"chardev-add"`,
-			`"id":"` + id + `"`,
+			`"id":"` + toQemuID(id) + `"`,
 		},
 		expectedRegExpArgs: []*regexp.Regexp{
 			regexp.MustCompile(`"path":"` + pathRegexpStr + id + `"`),
@@ -117,8 +117,8 @@ func (s *mockQmpCalls) ExpectAddVirtioBlk(id string, chardevID string) *mockQmpC
 		expectedArgs: []string{
 			`"execute":"device_add"`,
 			`"driver":"vhost-user-blk-pci"`,
-			`"id":"` + id + `"`,
-			`"chardev":"` + chardevID + `"`,
+			`"id":"` + toQemuID(id) + `"`,
+			`"chardev":"` + toQemuID(chardevID) + `"`,
 		},
 	})
 	return s
@@ -144,7 +144,7 @@ func (s *mockQmpCalls) ExpectDeleteChardev(id string) *mockQmpCalls {
 		response: genericQmpOk,
 		expectedArgs: []string{
 			`"execute":"chardev-remove"`,
-			`"id":"` + id + `"`,
+			`"id":"` + toQemuID(id) + `"`,
 		},
 	})
 	return s
@@ -154,7 +154,7 @@ func (s *mockQmpCalls) ExpectDeleteVirtioBlkWithEvent(id string) *mockQmpCalls {
 	s.ExpectDeleteVirtioBlk(id)
 	s.expectedCalls[len(s.expectedCalls)-1].event =
 		`{"event":"DEVICE_DELETED","data":{"path":"/some/path","device":"` +
-			id + `"},"timestamp":{"seconds":1,"microseconds":2}}` + "\n"
+			toQemuID(id) + `"},"timestamp":{"seconds":1,"microseconds":2}}` + "\n"
 	return s
 }
 

--- a/pkg/kvm/kvm_test.go
+++ b/pkg/kvm/kvm_test.go
@@ -124,16 +124,16 @@ func (s *mockQmpCalls) ExpectAddVirtioBlk(id string, chardevID string) *mockQmpC
 	return s
 }
 
-func (s *mockQmpCalls) ExpectAddNvmeController(id string) *mockQmpCalls {
+func (s *mockQmpCalls) ExpectAddNvmeController(id string, ctrlrDir string) *mockQmpCalls {
 	s.expectedCalls = append(s.expectedCalls, mockCall{
 		response: genericQmpOk,
 		expectedArgs: []string{
 			`"execute":"device_add"`,
 			`"driver":"vfio-user-pci"`,
-			`"id":"` + id + `"`,
+			`"id":"` + toQemuID(id) + `"`,
 		},
 		expectedRegExpArgs: []*regexp.Regexp{
-			regexp.MustCompile(`"socket":"` + pathRegexpStr + id + `/cntrl"`),
+			regexp.MustCompile(`"socket":"` + pathRegexpStr + ctrlrDir + `/cntrl"`),
 		},
 	})
 	return s
@@ -169,7 +169,7 @@ func (s *mockQmpCalls) ExpectDeleteNvmeController(id string) *mockQmpCalls {
 func (s *mockQmpCalls) ExpectQueryPci(id string) *mockQmpCalls {
 	response := `{"return":[{"bus":0,"devices":[{"bus":0,"slot":0,"function":0,` +
 		`"class_info":{"class":0},"id":{"device":0,"vendor":0},"qdev_id":"` +
-		id + `","regions":[]}]}]}` + "\n"
+		toQemuID(id) + `","regions":[]}]}]}` + "\n"
 	s.expectedCalls = append(s.expectedCalls, mockCall{
 		response: response,
 		expectedArgs: []string{
@@ -202,7 +202,7 @@ func (s *mockQmpCalls) expectDeleteDevice(id string) *mockQmpCalls {
 		response: genericQmpOk,
 		expectedArgs: []string{
 			`"execute":"device_del"`,
-			`"id":"` + id + `"`,
+			`"id":"` + toQemuID(id) + `"`,
 		},
 	})
 	return s

--- a/pkg/kvm/nvme.go
+++ b/pkg/kvm/nvme.go
@@ -43,7 +43,7 @@ func NewVfiouserSubsystemListener(ctrlrDir string) frontend.SubsystemListener {
 
 func (c *vfiouserSubsystemListener) Params(ctrlr *pb.NVMeController, nqn string) spdk.NvmfSubsystemAddListenerParams {
 	result := spdk.NvmfSubsystemAddListenerParams{}
-	ctrlrDirPath := controllerDirPath(c.ctrlrDir, ctrlr.Spec.Name)
+	ctrlrDirPath := controllerDirPath(c.ctrlrDir, ctrlr.Spec.SubsystemId.Value)
 	result.Nqn = nqn
 	result.ListenAddress.Trtype = "vfiouser"
 	result.ListenAddress.Traddr = ctrlrDirPath
@@ -53,8 +53,14 @@ func (c *vfiouserSubsystemListener) Params(ctrlr *pb.NVMeController, nqn string)
 
 // CreateNVMeController creates an NVMe controller device and attaches it to QEMU instance
 func (s *Server) CreateNVMeController(ctx context.Context, in *pb.CreateNVMeControllerRequest) (*pb.NVMeController, error) {
-	id := in.NvMeController.Spec.Name
-	err := createControllerDir(s.ctrlrDir, id)
+	if in.NvMeController.Spec.SubsystemId == nil || in.NvMeController.Spec.SubsystemId.Value == "" {
+		return nil, errInvalidSubsystem
+	}
+
+	// Create request can miss Name field which is generated in spdk bridge.
+	// Use subsystem instead, since it is required to exist
+	dirName := in.NvMeController.Spec.SubsystemId.Value
+	err := createControllerDir(s.ctrlrDir, dirName)
 	if err != nil {
 		log.Print(err)
 		return nil, errFailedToCreateNvmeDir
@@ -63,23 +69,25 @@ func (s *Server) CreateNVMeController(ctx context.Context, in *pb.CreateNVMeCont
 	out, err := s.Server.CreateNVMeController(ctx, in)
 	if err != nil {
 		log.Println("Error running cmd on opi-spdk bridge:", err)
-		_ = deleteControllerDir(s.ctrlrDir, id)
+		_ = deleteControllerDir(s.ctrlrDir, dirName)
 		return out, err
 	}
+	name := out.Spec.Name
 
 	mon, monErr := newMonitor(s.qmpAddress, s.protocol, s.timeout, s.pollDevicePresenceStep)
 	if monErr != nil {
 		log.Println("Couldn't create QEMU monitor")
-		_, _ = s.Server.DeleteNVMeController(context.Background(), &pb.DeleteNVMeControllerRequest{Name: id})
-		_ = deleteControllerDir(s.ctrlrDir, id)
+		_, _ = s.Server.DeleteNVMeController(context.Background(), &pb.DeleteNVMeControllerRequest{Name: name})
+		_ = deleteControllerDir(s.ctrlrDir, dirName)
 		return nil, errMonitorCreation
 	}
 	defer mon.Disconnect()
 
-	if err := mon.AddNvmeControllerDevice(id, controllerDirPath(s.ctrlrDir, id)); err != nil {
+	qemuDeviceID := toQemuID(name)
+	if err := mon.AddNvmeControllerDevice(qemuDeviceID, controllerDirPath(s.ctrlrDir, dirName)); err != nil {
 		log.Println("Couldn't add NVMe controller:", err)
-		_, _ = s.Server.DeleteNVMeController(context.Background(), &pb.DeleteNVMeControllerRequest{Name: id})
-		_ = deleteControllerDir(s.ctrlrDir, id)
+		_, _ = s.Server.DeleteNVMeController(context.Background(), &pb.DeleteNVMeControllerRequest{Name: name})
+		_ = deleteControllerDir(s.ctrlrDir, dirName)
 		return nil, errAddDeviceFailed
 	}
 	return out, nil
@@ -94,7 +102,14 @@ func (s *Server) DeleteNVMeController(ctx context.Context, in *pb.DeleteNVMeCont
 	}
 	defer mon.Disconnect()
 
-	delNvmeErr := mon.DeleteNvmeControllerDevice(in.Name)
+	dirName, findDirNameErr := s.findDirName(in.Name)
+	if findDirNameErr != nil {
+		log.Println("Failed to detect controller directory name:", findDirNameErr)
+		return nil, findDirNameErr
+	}
+
+	qemuDeviceID := toQemuID(in.Name)
+	delNvmeErr := mon.DeleteNvmeControllerDevice(qemuDeviceID)
 	if delNvmeErr != nil {
 		log.Printf("Couldn't delete NVMe controller: %v", delNvmeErr)
 	}
@@ -104,7 +119,7 @@ func (s *Server) DeleteNVMeController(ctx context.Context, in *pb.DeleteNVMeCont
 		log.Println("Error running underlying cmd on opi-spdk bridge:", spdkErr)
 	}
 
-	delDirErr := deleteControllerDir(s.ctrlrDir, in.Name)
+	delDirErr := deleteControllerDir(s.ctrlrDir, dirName)
 	if delDirErr != nil {
 		log.Println("Failed to delete NVMe controller directory:", delDirErr)
 	}
@@ -118,18 +133,26 @@ func (s *Server) DeleteNVMeController(ctx context.Context, in *pb.DeleteNVMeCont
 	return response, err
 }
 
-func createControllerDir(ctrlrDir string, ctrlrID string) error {
-	ctrlrDirPath := controllerDirPath(ctrlrDir, ctrlrID)
-	log.Printf("Creating dir for %v NVMe controller: %v", ctrlrID, ctrlrDirPath)
+func (s *Server) findDirName(name string) (string, error) {
+	ctrlr, ok := s.Server.Nvme.Controllers[name]
+	if !ok {
+		return "", errNoController
+	}
+	return ctrlr.Spec.SubsystemId.Value, nil
+}
+
+func createControllerDir(ctrlrDir string, dirName string) error {
+	ctrlrDirPath := controllerDirPath(ctrlrDir, dirName)
+	log.Printf("Creating dir for NVMe controller: %v", ctrlrDirPath)
 	if os.Mkdir(ctrlrDirPath, 0600) != nil {
 		return fmt.Errorf("cannot create controller directory %v", ctrlrDirPath)
 	}
 	return nil
 }
 
-func deleteControllerDir(ctrlrDir string, ctrlrID string) error {
-	ctrlrDirPath := controllerDirPath(ctrlrDir, ctrlrID)
-	log.Printf("Deleting dir for %v NVMe controller: %v", ctrlrID, ctrlrDirPath)
+func deleteControllerDir(ctrlrDir string, dirName string) error {
+	ctrlrDirPath := controllerDirPath(ctrlrDir, dirName)
+	log.Printf("Deleting dir for NVMe controller: %v", ctrlrDirPath)
 	if _, err := os.Stat(ctrlrDirPath); os.IsNotExist(err) {
 		log.Printf("%v directory does not exist.", ctrlrDirPath)
 		return nil


### PR DESCRIPTION
opi-spdk-bridge can generate NVMe controller id if it is not provided and build controller name. Those names can add some issues for KVM related code:
For NVMe ad virtio-blk:
* QMP requires object ids start from a letter. An SPDK bridge uses uuid if an id is not specified. Add toQemuID function to add prefixes to QEMU related ids which are based on controller names.

For NVMe controller only:
* NVMe controller directory should exist before an SPDK request to create that controller is sent. NVMe controller id/name cannot be used as directory name since it is not a mandatory field. Use subsystem id instead, since it must exist before a controller is created.

After this PR, https://github.com/opiproject/opi-spdk-bridge/pull/335 can be rebased and merged