### PR TITLE
rename: resourceId is a better name

### DIFF
--- a/pkg/backend/aio.go
+++ b/pkg/backend/aio.go
@@ -79,9 +79,9 @@ func (s *Server) DeleteAioController(_ context.Context, in *pb.DeleteAioControll
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
+	resourceID := path.Base(volume.Name)
 	params := spdk.BdevAioDeleteParams{
-		Name: name,
+		Name: resourceID,
 	}
 	var result spdk.BdevAioDeleteResult
 	err := s.rpc.Call("bdev_aio_delete", &params, &result)
@@ -102,9 +102,9 @@ func (s *Server) DeleteAioController(_ context.Context, in *pb.DeleteAioControll
 // UpdateAioController updates an Aio controller
 func (s *Server) UpdateAioController(_ context.Context, in *pb.UpdateAioControllerRequest) (*pb.AioController, error) {
 	log.Printf("UpdateAioController: Received from client: %v", in)
-	name := path.Base(in.AioController.Name)
+	resourceID := path.Base(in.AioController.Name)
 	params1 := spdk.BdevAioDeleteParams{
-		Name: name,
+		Name: resourceID,
 	}
 	var result1 spdk.BdevAioDeleteResult
 	err1 := s.rpc.Call("bdev_aio_delete", &params1, &result1)
@@ -119,7 +119,7 @@ func (s *Server) UpdateAioController(_ context.Context, in *pb.UpdateAioControll
 		return nil, status.Errorf(codes.InvalidArgument, msg)
 	}
 	params2 := spdk.BdevAioCreateParams{
-		Name:      name,
+		Name:      resourceID,
 		BlockSize: 512,
 		Filename:  in.AioController.Filename,
 	}
@@ -180,9 +180,9 @@ func (s *Server) GetAioController(_ context.Context, in *pb.GetAioControllerRequ
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
+	resourceID := path.Base(volume.Name)
 	params := spdk.BdevGetBdevsParams{
-		Name: name,
+		Name: resourceID,
 	}
 	var result []spdk.BdevGetBdevsResult
 	err := s.rpc.Call("bdev_get_bdevs", &params, &result)
@@ -208,9 +208,9 @@ func (s *Server) AioControllerStats(_ context.Context, in *pb.AioControllerStats
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
+	resourceID := path.Base(volume.Name)
 	params := spdk.BdevGetIostatParams{
-		Name: name,
+		Name: resourceID,
 	}
 	// See https://mholt.github.io/json-to-go/
 	var result spdk.BdevGetIostatResult

--- a/pkg/backend/null.go
+++ b/pkg/backend/null.go
@@ -80,9 +80,9 @@ func (s *Server) DeleteNullDebug(_ context.Context, in *pb.DeleteNullDebugReques
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
+	resourceID := path.Base(volume.Name)
 	params := spdk.BdevNullDeleteParams{
-		Name: name,
+		Name: resourceID,
 	}
 	var result spdk.BdevNullDeleteResult
 	err := s.rpc.Call("bdev_null_delete", &params, &result)
@@ -103,9 +103,9 @@ func (s *Server) DeleteNullDebug(_ context.Context, in *pb.DeleteNullDebugReques
 // UpdateNullDebug updates a Null Debug instance
 func (s *Server) UpdateNullDebug(_ context.Context, in *pb.UpdateNullDebugRequest) (*pb.NullDebug, error) {
 	log.Printf("UpdateNullDebug: Received from client: %v", in)
-	name := path.Base(in.NullDebug.Name)
+	resourceID := path.Base(in.NullDebug.Name)
 	params1 := spdk.BdevNullDeleteParams{
-		Name: name,
+		Name: resourceID,
 	}
 	var result1 spdk.BdevNullDeleteResult
 	err1 := s.rpc.Call("bdev_null_delete", &params1, &result1)
@@ -120,7 +120,7 @@ func (s *Server) UpdateNullDebug(_ context.Context, in *pb.UpdateNullDebugReques
 		return nil, status.Errorf(codes.InvalidArgument, msg)
 	}
 	params2 := spdk.BdevNullCreateParams{
-		Name:      name,
+		Name:      resourceID,
 		BlockSize: 512,
 		NumBlocks: 64,
 	}
@@ -181,9 +181,9 @@ func (s *Server) GetNullDebug(_ context.Context, in *pb.GetNullDebugRequest) (*p
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
+	resourceID := path.Base(volume.Name)
 	params := spdk.BdevGetBdevsParams{
-		Name: name,
+		Name: resourceID,
 	}
 	var result []spdk.BdevGetBdevsResult
 	err := s.rpc.Call("bdev_get_bdevs", &params, &result)
@@ -209,9 +209,9 @@ func (s *Server) NullDebugStats(_ context.Context, in *pb.NullDebugStatsRequest)
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
+	resourceID := path.Base(volume.Name)
 	params := spdk.BdevGetIostatParams{
-		Name: name,
+		Name: resourceID,
 	}
 	// See https://mholt.github.io/json-to-go/
 	var result spdk.BdevGetIostatResult

--- a/pkg/frontend/blk.go
+++ b/pkg/frontend/blk.go
@@ -146,9 +146,9 @@ func (s *Server) GetVirtioBlk(_ context.Context, in *pb.GetVirtioBlkRequest) (*p
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
+	resourceID := path.Base(volume.Name)
 	params := spdk.VhostGetControllersParams{
-		Name: name,
+		Name: resourceID,
 	}
 	var result []spdk.VhostGetControllersResult
 	err := s.rpc.Call("vhost_get_controllers", &params, &result)
@@ -177,7 +177,7 @@ func (s *Server) VirtioBlkStats(_ context.Context, in *pb.VirtioBlkStatsRequest)
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
-	log.Printf("TODO: send anme to SPDK and get back stats: %v", name)
+	resourceID := path.Base(volume.Name)
+	log.Printf("TODO: send anme to SPDK and get back stats: %v", resourceID)
 	return nil, status.Errorf(codes.Unimplemented, "VirtioBlkStats method is not implemented")
 }

--- a/pkg/frontend/nvme.go
+++ b/pkg/frontend/nvme.go
@@ -248,8 +248,8 @@ func (s *Server) NvmeSubsystemStats(_ context.Context, in *pb.NvmeSubsystemStats
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
-	log.Printf("TODO: send anme to SPDK and get back stats: %v", name)
+	resourceID := path.Base(volume.Name)
+	log.Printf("TODO: send anme to SPDK and get back stats: %v", resourceID)
 	var result spdk.NvmfGetSubsystemStatsResult
 	err := s.rpc.Call("nvmf_get_stats", nil, &result)
 	if err != nil {
@@ -388,8 +388,8 @@ func (s *Server) NvmeControllerStats(_ context.Context, in *pb.NvmeControllerSta
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
-	log.Printf("TODO: send anme to SPDK and get back stats: %v", name)
+	resourceID := path.Base(volume.Name)
+	log.Printf("TODO: send anme to SPDK and get back stats: %v", resourceID)
 	return &pb.NvmeControllerStatsResponse{Stats: &pb.VolumeStats{ReadOpsCount: -1, WriteOpsCount: -1}}, nil
 }
 
@@ -609,7 +609,7 @@ func (s *Server) NvmeNamespaceStats(_ context.Context, in *pb.NvmeNamespaceStats
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
-	log.Printf("TODO: send anme to SPDK and get back stats: %v", name)
+	resourceID := path.Base(volume.Name)
+	log.Printf("TODO: send anme to SPDK and get back stats: %v", resourceID)
 	return &pb.NvmeNamespaceStatsResponse{Stats: &pb.VolumeStats{ReadOpsCount: -1, WriteOpsCount: -1}}, nil
 }

--- a/pkg/frontend/scsi.go
+++ b/pkg/frontend/scsi.go
@@ -140,9 +140,9 @@ func (s *Server) GetVirtioScsiController(_ context.Context, in *pb.GetVirtioScsi
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
+	resourceID := path.Base(volume.Name)
 	params := spdk.VhostGetControllersParams{
-		Name: name,
+		Name: resourceID,
 	}
 	var result []spdk.VhostGetControllersResult
 	err := s.rpc.Call("vhost_get_controllers", &params, &result)
@@ -168,8 +168,8 @@ func (s *Server) VirtioScsiControllerStats(_ context.Context, in *pb.VirtioScsiC
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
-	log.Printf("TODO: send anme to SPDK and get back stats: %v", name)
+	resourceID := path.Base(volume.Name)
+	log.Printf("TODO: send anme to SPDK and get back stats: %v", resourceID)
 	return &pb.VirtioScsiControllerStatsResponse{}, nil
 }
 
@@ -290,9 +290,9 @@ func (s *Server) GetVirtioScsiLun(_ context.Context, in *pb.GetVirtioScsiLunRequ
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
+	resourceID := path.Base(volume.Name)
 	params := spdk.VhostGetControllersParams{
-		Name: name,
+		Name: resourceID,
 	}
 	var result []spdk.VhostGetControllersResult
 	err := s.rpc.Call("vhost_get_controllers", &params, &result)
@@ -318,7 +318,7 @@ func (s *Server) VirtioScsiLunStats(_ context.Context, in *pb.VirtioScsiLunStats
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
-	log.Printf("TODO: send anme to SPDK and get back stats: %v", name)
+	resourceID := path.Base(volume.Name)
+	log.Printf("TODO: send anme to SPDK and get back stats: %v", resourceID)
 	return &pb.VirtioScsiLunStatsResponse{}, nil
 }

--- a/pkg/middleend/encryption.go
+++ b/pkg/middleend/encryption.go
@@ -100,9 +100,9 @@ func (s *Server) DeleteEncryptedVolume(_ context.Context, in *pb.DeleteEncrypted
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
+	resourceID := path.Base(volume.Name)
 	bdevCryptoDeleteParams := spdk.BdevCryptoDeleteParams{
-		Name: name,
+		Name: resourceID,
 	}
 	var bdevCryptoDeleteResult spdk.BdevCryptoDeleteResult
 	err := s.rpc.Call("bdev_crypto_delete", &bdevCryptoDeleteParams, &bdevCryptoDeleteResult)
@@ -118,7 +118,7 @@ func (s *Server) DeleteEncryptedVolume(_ context.Context, in *pb.DeleteEncrypted
 	}
 
 	keyDestroyParams := spdk.AccelCryptoKeyDestroyParams{
-		KeyName: name,
+		KeyName: resourceID,
 	}
 	var keyDestroyResult spdk.AccelCryptoKeyDestroyResult
 	err = s.rpc.Call("accel_crypto_key_destroy", &keyDestroyParams, &keyDestroyResult)
@@ -144,10 +144,10 @@ func (s *Server) UpdateEncryptedVolume(_ context.Context, in *pb.UpdateEncrypted
 		log.Printf("error: %v", err)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	name := path.Base(in.EncryptedVolume.Name)
+	resourceID := path.Base(in.EncryptedVolume.Name)
 	// first delete old bdev
 	params1 := spdk.BdevCryptoDeleteParams{
-		Name: name,
+		Name: resourceID,
 	}
 	var result1 spdk.BdevCryptoDeleteResult
 	err1 := s.rpc.Call("bdev_crypto_delete", &params1, &result1)
@@ -163,7 +163,7 @@ func (s *Server) UpdateEncryptedVolume(_ context.Context, in *pb.UpdateEncrypted
 	}
 	// now delete a key
 	params0 := spdk.AccelCryptoKeyDestroyParams{
-		KeyName: name,
+		KeyName: resourceID,
 	}
 	var result0 spdk.AccelCryptoKeyDestroyResult
 	err0 := s.rpc.Call("accel_crypto_key_destroy", &params0, &result0)
@@ -192,9 +192,9 @@ func (s *Server) UpdateEncryptedVolume(_ context.Context, in *pb.UpdateEncrypted
 	}
 	// create bdev now
 	params3 := spdk.BdevCryptoCreateParams{
-		Name:         name,
+		Name:         resourceID,
 		BaseBdevName: in.EncryptedVolume.VolumeId.Value,
-		KeyName:      name,
+		KeyName:      resourceID,
 	}
 	var result3 spdk.BdevCryptoCreateResult
 	err3 := s.rpc.Call("bdev_crypto_create", &params3, &result3)
@@ -254,9 +254,9 @@ func (s *Server) GetEncryptedVolume(_ context.Context, in *pb.GetEncryptedVolume
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
+	resourceID := path.Base(volume.Name)
 	params := spdk.BdevGetBdevsParams{
-		Name: name,
+		Name: resourceID,
 	}
 	var result []spdk.BdevGetBdevsResult
 	err := s.rpc.Call("bdev_get_bdevs", &params, &result)
@@ -282,9 +282,9 @@ func (s *Server) EncryptedVolumeStats(_ context.Context, in *pb.EncryptedVolumeS
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	name := path.Base(volume.Name)
+	resourceID := path.Base(volume.Name)
 	params := spdk.BdevGetIostatParams{
-		Name: name,
+		Name: resourceID,
 	}
 	// See https://mholt.github.io/json-to-go/
 	var result spdk.BdevGetIostatResult


### PR DESCRIPTION
Fixes #417

According to AIP-122 a resource name includes a resource ID.
That part which is extracted by path.Base is probably resource ID, not name

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
