### PR TITLE
align proto clone to the same pattern

### DIFF
--- a/pkg/frontend/blk.go
+++ b/pkg/frontend/blk.go
@@ -68,9 +68,9 @@ func (s *Server) CreateVirtioBlk(_ context.Context, in *pb.CreateVirtioBlkReques
 		log.Printf("Could not create: %v", in)
 		return nil, fmt.Errorf("%w for %v", spdk.ErrUnexpectedSpdkCallResult, in)
 	}
-	s.Virt.BlkCtrls[in.VirtioBlk.Name] = in.VirtioBlk
-	// s.VirtioCtrls[in.VirtioBlk.Name].Status = &pb.NvmeControllerStatus{Active: true}
 	response := server.ProtoClone(in.VirtioBlk)
+	// response.Status = &pb.NvmeControllerStatus{Active: true}
+	s.Virt.BlkCtrls[in.VirtioBlk.Name] = response
 	return response, nil
 }
 

--- a/pkg/frontend/nvme.go
+++ b/pkg/frontend/nvme.go
@@ -329,10 +329,10 @@ func (s *Server) CreateNvmeController(_ context.Context, in *pb.CreateNvmeContro
 		log.Print(msg)
 		return nil, status.Errorf(codes.InvalidArgument, msg)
 	}
-	s.Nvme.Controllers[in.NvmeController.Name] = in.NvmeController
-	s.Nvme.Controllers[in.NvmeController.Name].Spec.NvmeControllerId = -1
-	s.Nvme.Controllers[in.NvmeController.Name].Status = &pb.NvmeControllerStatus{Active: true}
 	response := server.ProtoClone(in.NvmeController)
+	response.Spec.NvmeControllerId = -1
+	response.Status = &pb.NvmeControllerStatus{Active: true}
+	s.Nvme.Controllers[in.NvmeController.Name] = response
 
 	return response, nil
 }
@@ -392,9 +392,9 @@ func (s *Server) UpdateNvmeController(_ context.Context, in *pb.UpdateNvmeContro
 		return nil, err
 	}
 	log.Printf("TODO: use resourceID=%v", resourceID)
-	s.Nvme.Controllers[in.NvmeController.Name] = in.NvmeController
-	s.Nvme.Controllers[in.NvmeController.Name].Status = &pb.NvmeControllerStatus{Active: true}
 	response := server.ProtoClone(in.NvmeController)
+	response.Status = &pb.NvmeControllerStatus{Active: true}
+	s.Nvme.Controllers[in.NvmeController.Name] = response
 	return response, nil
 }
 
@@ -490,10 +490,10 @@ func (s *Server) CreateNvmeNamespace(_ context.Context, in *pb.CreateNvmeNamespa
 		log.Print(msg)
 		return nil, status.Errorf(codes.InvalidArgument, msg)
 	}
-	s.Nvme.Namespaces[in.NvmeNamespace.Name] = in.NvmeNamespace
 
 	response := server.ProtoClone(in.NvmeNamespace)
 	response.Status = &pb.NvmeNamespaceStatus{PciState: 2, PciOperState: 1}
+	s.Nvme.Namespaces[in.NvmeNamespace.Name] = response
 	return response, nil
 }
 
@@ -555,10 +555,10 @@ func (s *Server) UpdateNvmeNamespace(_ context.Context, in *pb.UpdateNvmeNamespa
 		return nil, err
 	}
 	log.Printf("TODO: use resourceID=%v", resourceID)
-	s.Nvme.Namespaces[in.NvmeNamespace.Name] = in.NvmeNamespace
-	s.Nvme.Namespaces[in.NvmeNamespace.Name].Status = &pb.NvmeNamespaceStatus{PciState: 2, PciOperState: 1}
-
 	response := server.ProtoClone(in.NvmeNamespace)
+	response.Status = &pb.NvmeNamespaceStatus{PciState: 2, PciOperState: 1}
+	s.Nvme.Namespaces[in.NvmeNamespace.Name] = response
+
 	return response, nil
 }
 

--- a/pkg/frontend/scsi.go
+++ b/pkg/frontend/scsi.go
@@ -66,9 +66,9 @@ func (s *Server) CreateVirtioScsiController(_ context.Context, in *pb.CreateVirt
 	if !result {
 		log.Printf("Could not create: %v", in)
 	}
-	s.Virt.ScsiCtrls[in.VirtioScsiController.Name] = in.VirtioScsiController
-	// s.VirtioCtrls[in.VirtioScsiController.Name].Status = &pb.VirtioScsiControllerStatus{Active: true}
 	response := server.ProtoClone(in.VirtioScsiController)
+	// response.Status = &pb.VirtioScsiControllerStatus{Active: true}
+	s.Virt.ScsiCtrls[in.VirtioScsiController.Name] = response
 	return response, nil
 }
 
@@ -234,9 +234,9 @@ func (s *Server) CreateVirtioScsiLun(_ context.Context, in *pb.CreateVirtioScsiL
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
-	s.Virt.ScsiLuns[in.VirtioScsiLun.Name] = in.VirtioScsiLun
-	// s.ScsiLuns[in.VirtioScsiLun.Name].Status = &pb.VirtioScsiLunStatus{Active: true}
 	response := server.ProtoClone(in.VirtioScsiLun)
+	// response.Status = &pb.VirtioScsiLunStatus{Active: true}
+	s.Virt.ScsiLuns[in.VirtioScsiLun.Name] = response
 	return response, nil
 }
 


### PR DESCRIPTION
that is separate the input from the assigned and the return object.

Fix issue #438