### PR TITLE
frontend/namespace: store auto assigned host nsid for namespace

### DIFF
--- a/pkg/frontend/nvme_namespace.go
+++ b/pkg/frontend/nvme_namespace.go
@@ -94,6 +94,7 @@ func (s *Server) CreateNvmeNamespace(_ context.Context, in *pb.CreateNvmeNamespa
 
 	response := server.ProtoClone(in.NvmeNamespace)
 	response.Status = &pb.NvmeNamespaceStatus{PciState: 2, PciOperState: 1}
+	response.Spec.HostNsid = int32(result)
 	s.Nvme.Namespaces[in.NvmeNamespace.Name] = response
 	return response, nil
 }


### PR DESCRIPTION
When no HostNsid is present 'nvmf_subsystem_add_ns' will auto assign an id which is needed for removing namespace from the subsystem.