### PR TITLE
Add OpenSSF scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,22 @@
+name: OpenSSF
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  call:
+    permissions:
+      # Keep in sync with opi-smbios-bridge, no direct way to inherit permissions
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read
+    uses: opiproject/opi-smbios-bridge/.github/workflows/scorecard.yml@main
+    secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,16 +7,7 @@ on:
   pull_request:
     branches: [ main ]
 
-permissions:
-  contents: read
-
 jobs:
   call:
-    permissions:
-      # Keep in sync with opi-smbios-bridge, no direct way to inherit permissions
-      contents: read
-      security-events: write
-      id-token: write
-      actions: read
     uses: opiproject/opi-smbios-bridge/.github/workflows/scorecard.yml@main
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Linters](https://github.com/opiproject/opi-spdk-bridge/actions/workflows/linters.yml/badge.svg)](https://github.com/opiproject/opi-spdk-bridge/actions/workflows/linters.yml)
 [![CodeQL](https://github.com/opiproject/opi-spdk-bridge/actions/workflows/codeql.yml/badge.svg)](https://github.com/opiproject/opi-spdk-bridge/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/opiproject/opi-spdk-bridge/badge)](https://securityscorecards.dev/viewer/?platform=github.com&org=opiproject&repo=opi-spdk-bridge)
 [![tests](https://github.com/opiproject/opi-spdk-bridge/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/opiproject/opi-spdk-bridge/actions/workflows/docker-publish.yml)
 [![License](https://img.shields.io/github/license/opiproject/opi-spdk-bridge?style=flat-square&color=blue&label=License)](https://github.com/opiproject/opi-spdk-bridge/blob/master/LICENSE)
 [![codecov](https://codecov.io/gh/opiproject/opi-spdk-bridge/branch/main/graph/badge.svg)](https://codecov.io/gh/opiproject/opi-spdk-bridge)


### PR DESCRIPTION
Ensure following best open source security practices by monitoring OpenSSF score of the project.