### PR TITLE
keep opi-api version in built image's label

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,6 +52,9 @@ jobs:
           ${{ github.repository }}
           ghcr.io/${{ github.repository }}
 
+    - name: Get opi-api Version
+      run: echo "OPI_API_VERSION=$(go list -m -f '{{.Version}}' github.com/opiproject/opi-api)" >> $GITHUB_ENV
+
     - name: Build and push Docker image
       uses: docker/build-push-action@v4.1.1
       with:
@@ -62,6 +65,8 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        build-args: |
+          OPI_API_VERSION=$OPI_API_VERSION
 
   storage-ci:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 # Copyright (c) 2022-2023 Dell Inc, or its subsidiaries.
 
 FROM docker.io/library/golang:1.21.0-alpine as builder
-
+ARG OPI_API_VERSION
+LABEL opi-api-version=${OPI_API_VERSION}
 WORKDIR /app
 
 # Download necessary Go modules


### PR DESCRIPTION
Solution for https://github.com/opiproject/opi-spdk-bridge/issues/576

Example usage:
```bash
# docker build . --build-arg="OPI_API_VERSION=test" -t opiproject/opi-spdk-bridge

# docker inspect 45fe98b6d6dd --format '{{ json .Config.Labels }}' | sed 's/,/\n/g'
{"opi_api_version":"test"}

# docker build . --label "opi_api_version=test1" -t opiproject/opi-spdk-bridge

# docker inspect 1304b6107289 --format '{{ json .Config.Labels }}' | sed 's/,/\n/g'
{"opi_api_version":"test1"}
```