### PR TITLE
ci: keep opi-api version in built image's label

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,6 +52,9 @@ jobs:
           ${{ github.repository }}
           ghcr.io/${{ github.repository }}
 
+    - name: Get opi-api Version
+      run: echo "OPI_API_VERSION=$(go list -m -f '{{.Version}}' github.com/opiproject/opi-api)" >> $GITHUB_ENV
+
     - name: Build and push Docker image
       uses: docker/build-push-action@v4.1.1
       with:
@@ -59,7 +62,9 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+        labels: |
+          ${{ steps.meta.outputs.labels }},
+          opi-api-version=${{ env.OPI_API_VERSION }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
 


### PR DESCRIPTION
fix https://github.com/opiproject/opi-spdk-bridge/issues/576