### PR TITLE
refactor: split validate logic to a new file

### DIFF
--- a/pkg/backend/aio.go
+++ b/pkg/backend/aio.go
@@ -20,7 +20,6 @@ import (
 	"go.einride.tech/aip/fieldbehavior"
 	"go.einride.tech/aip/fieldmask"
 	"go.einride.tech/aip/resourceid"
-	"go.einride.tech/aip/resourcename"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -35,19 +34,14 @@ func sortAioVolumes(volumes []*pb.AioVolume) {
 // CreateAioVolume creates an Aio volume
 func (s *Server) CreateAioVolume(_ context.Context, in *pb.CreateAioVolumeRequest) (*pb.AioVolume, error) {
 	log.Printf("CreateAioVolume: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+	// check input correctness
+	if err := s.validateCreateAioVolumeRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
 	// see https://google.aip.dev/133#user-specified-ids
 	resourceID := resourceid.NewSystemGenerated()
 	if in.AioVolumeId != "" {
-		err := resourceid.ValidateUserSettable(in.AioVolumeId)
-		if err != nil {
-			log.Printf("error: %v", err)
-			return nil, err
-		}
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.AioVolumeId, in.AioVolume.Name)
 		resourceID = in.AioVolumeId
 	}
@@ -85,13 +79,8 @@ func (s *Server) CreateAioVolume(_ context.Context, in *pb.CreateAioVolumeReques
 // DeleteAioVolume deletes an Aio volume
 func (s *Server) DeleteAioVolume(_ context.Context, in *pb.DeleteAioVolumeRequest) (*emptypb.Empty, error) {
 	log.Printf("DeleteAioVolume: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateDeleteAioVolumeRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -128,13 +117,8 @@ func (s *Server) DeleteAioVolume(_ context.Context, in *pb.DeleteAioVolumeReques
 // UpdateAioVolume updates an Aio volume
 func (s *Server) UpdateAioVolume(_ context.Context, in *pb.UpdateAioVolumeRequest) (*pb.AioVolume, error) {
 	log.Printf("UpdateAioVolume: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.AioVolume.Name); err != nil {
+	// check input correctness
+	if err := s.validateUpdateAioVolumeRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -252,13 +236,8 @@ func (s *Server) ListAioVolumes(_ context.Context, in *pb.ListAioVolumesRequest)
 // GetAioVolume gets an Aio volume
 func (s *Server) GetAioVolume(_ context.Context, in *pb.GetAioVolumeRequest) (*pb.AioVolume, error) {
 	log.Printf("GetAioVolume: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateGetAioVolumeRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -291,13 +270,8 @@ func (s *Server) GetAioVolume(_ context.Context, in *pb.GetAioVolumeRequest) (*p
 // StatsAioVolume gets an Aio volume stats
 func (s *Server) StatsAioVolume(_ context.Context, in *pb.StatsAioVolumeRequest) (*pb.StatsAioVolumeResponse, error) {
 	log.Printf("StatsAioVolume: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateStatsAioVolumeRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}

--- a/pkg/backend/aio_validate.go
+++ b/pkg/backend/aio_validate.go
@@ -3,3 +3,62 @@
 
 // Package backend implememnts the BackEnd APIs (network facing) of the storage Server
 package backend
+
+import (
+	"go.einride.tech/aip/fieldbehavior"
+	"go.einride.tech/aip/resourceid"
+	"go.einride.tech/aip/resourcename"
+
+	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+)
+
+func (s *Server) validateCreateAioVolumeRequest(in *pb.CreateAioVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.AioVolumeId != "" {
+		if err := resourceid.ValidateUserSettable(in.AioVolumeId); err != nil {
+			return err
+		}
+	}
+	// TODO: validate also: block_size, blocks_count, uuid, filename
+	return nil
+}
+
+func (s *Server) validateDeleteAioVolumeRequest(in *pb.DeleteAioVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateUpdateAioVolumeRequest(in *pb.UpdateAioVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.AioVolume.Name)
+}
+
+func (s *Server) validateGetAioVolumeRequest(in *pb.GetAioVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateStatsAioVolumeRequest(in *pb.StatsAioVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}

--- a/pkg/backend/aio_validate.go
+++ b/pkg/backend/aio_validate.go
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2023 Dell Inc, or its subsidiaries.
+
+// Package backend implememnts the BackEnd APIs (network facing) of the storage Server
+package backend

--- a/pkg/backend/null.go
+++ b/pkg/backend/null.go
@@ -21,7 +21,6 @@ import (
 	"go.einride.tech/aip/fieldbehavior"
 	"go.einride.tech/aip/fieldmask"
 	"go.einride.tech/aip/resourceid"
-	"go.einride.tech/aip/resourcename"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -36,19 +35,14 @@ func sortNullVolumes(volumes []*pb.NullVolume) {
 // CreateNullVolume creates a Null volume instance
 func (s *Server) CreateNullVolume(_ context.Context, in *pb.CreateNullVolumeRequest) (*pb.NullVolume, error) {
 	log.Printf("CreateNullVolume: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+	// check input correctness
+	if err := s.validateCreateNullVolumeRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
 	// see https://google.aip.dev/133#user-specified-ids
 	resourceID := resourceid.NewSystemGenerated()
 	if in.NullVolumeId != "" {
-		err := resourceid.ValidateUserSettable(in.NullVolumeId)
-		if err != nil {
-			log.Printf("error: %v", err)
-			return nil, err
-		}
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NullVolumeId, in.NullVolume.Name)
 		resourceID = in.NullVolumeId
 	}
@@ -86,13 +80,8 @@ func (s *Server) CreateNullVolume(_ context.Context, in *pb.CreateNullVolumeRequ
 // DeleteNullVolume deletes a Null volume instance
 func (s *Server) DeleteNullVolume(_ context.Context, in *pb.DeleteNullVolumeRequest) (*emptypb.Empty, error) {
 	log.Printf("DeleteNullVolume: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateDeleteNullVolumeRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -129,13 +118,8 @@ func (s *Server) DeleteNullVolume(_ context.Context, in *pb.DeleteNullVolumeRequ
 // UpdateNullVolume updates a Null volume instance
 func (s *Server) UpdateNullVolume(_ context.Context, in *pb.UpdateNullVolumeRequest) (*pb.NullVolume, error) {
 	log.Printf("UpdateNullVolume: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.NullVolume.Name); err != nil {
+	// check input correctness
+	if err := s.validateUpdateNullVolumeRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -253,13 +237,8 @@ func (s *Server) ListNullVolumes(_ context.Context, in *pb.ListNullVolumesReques
 // GetNullVolume gets a a Null volume instance
 func (s *Server) GetNullVolume(_ context.Context, in *pb.GetNullVolumeRequest) (*pb.NullVolume, error) {
 	log.Printf("GetNullVolume: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateGetNullVolumeRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -292,13 +271,8 @@ func (s *Server) GetNullVolume(_ context.Context, in *pb.GetNullVolumeRequest) (
 // StatsNullVolume gets a Null volume instance stats
 func (s *Server) StatsNullVolume(_ context.Context, in *pb.StatsNullVolumeRequest) (*pb.StatsNullVolumeResponse, error) {
 	log.Printf("StatsNullVolume: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateStatsNullVolumeRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}

--- a/pkg/backend/null_validate.go
+++ b/pkg/backend/null_validate.go
@@ -3,3 +3,62 @@
 
 // Package backend implememnts the BackEnd APIs (network facing) of the storage Server
 package backend
+
+import (
+	"go.einride.tech/aip/fieldbehavior"
+	"go.einride.tech/aip/resourceid"
+	"go.einride.tech/aip/resourcename"
+
+	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+)
+
+func (s *Server) validateCreateNullVolumeRequest(in *pb.CreateNullVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.NullVolumeId != "" {
+		if err := resourceid.ValidateUserSettable(in.NullVolumeId); err != nil {
+			return err
+		}
+	}
+	// TODO: validate also: block_size, blocks_count, uuid
+	return nil
+}
+
+func (s *Server) validateDeleteNullVolumeRequest(in *pb.DeleteNullVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateUpdateNullVolumeRequest(in *pb.UpdateNullVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.NullVolume.Name)
+}
+
+func (s *Server) validateGetNullVolumeRequest(in *pb.GetNullVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateStatsNullVolumeRequest(in *pb.StatsNullVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}

--- a/pkg/backend/null_validate.go
+++ b/pkg/backend/null_validate.go
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2023 Dell Inc, or its subsidiaries.
+
+// Package backend implememnts the BackEnd APIs (network facing) of the storage Server
+package backend

--- a/pkg/backend/nvme_controller.go
+++ b/pkg/backend/nvme_controller.go
@@ -17,7 +17,6 @@ import (
 	"github.com/google/uuid"
 	"go.einride.tech/aip/fieldbehavior"
 	"go.einride.tech/aip/resourceid"
-	"go.einride.tech/aip/resourcename"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -32,19 +31,14 @@ func sortNvmeRemoteControllers(controllers []*pb.NvmeRemoteController) {
 // CreateNvmeRemoteController creates an Nvme remote controller
 func (s *Server) CreateNvmeRemoteController(_ context.Context, in *pb.CreateNvmeRemoteControllerRequest) (*pb.NvmeRemoteController, error) {
 	log.Printf("CreateNvmeRemoteController: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+	// check input correctness
+	if err := s.validateCreateNvmeRemoteControllerRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
 	// see https://google.aip.dev/133#user-specified-ids
 	resourceID := resourceid.NewSystemGenerated()
 	if in.NvmeRemoteControllerId != "" {
-		err := resourceid.ValidateUserSettable(in.NvmeRemoteControllerId)
-		if err != nil {
-			log.Printf("error: %v", err)
-			return nil, err
-		}
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvmeRemoteControllerId, in.NvmeRemoteController.Name)
 		resourceID = in.NvmeRemoteControllerId
 	}
@@ -65,13 +59,8 @@ func (s *Server) CreateNvmeRemoteController(_ context.Context, in *pb.CreateNvme
 // DeleteNvmeRemoteController deletes an Nvme remote controller
 func (s *Server) DeleteNvmeRemoteController(_ context.Context, in *pb.DeleteNvmeRemoteControllerRequest) (*emptypb.Empty, error) {
 	log.Printf("DeleteNvmeRemoteController: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateDeleteNvmeRemoteControllerRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -95,13 +84,8 @@ func (s *Server) DeleteNvmeRemoteController(_ context.Context, in *pb.DeleteNvme
 // ResetNvmeRemoteController resets an Nvme remote controller
 func (s *Server) ResetNvmeRemoteController(_ context.Context, in *pb.ResetNvmeRemoteControllerRequest) (*emptypb.Empty, error) {
 	log.Printf("Received: %v", in.GetName())
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateResetNvmeRemoteControllerRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -142,13 +126,8 @@ func (s *Server) ListNvmeRemoteControllers(_ context.Context, in *pb.ListNvmeRem
 // GetNvmeRemoteController gets an Nvme remote controller
 func (s *Server) GetNvmeRemoteController(_ context.Context, in *pb.GetNvmeRemoteControllerRequest) (*pb.NvmeRemoteController, error) {
 	log.Printf("GetNvmeRemoteController: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateGetNvmeRemoteControllerRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -167,13 +146,8 @@ func (s *Server) GetNvmeRemoteController(_ context.Context, in *pb.GetNvmeRemote
 // StatsNvmeRemoteController gets Nvme remote controller stats
 func (s *Server) StatsNvmeRemoteController(_ context.Context, in *pb.StatsNvmeRemoteControllerRequest) (*pb.StatsNvmeRemoteControllerResponse, error) {
 	log.Printf("Received: %v", in.GetName())
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateStatsNvmeRemoteControllerRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}

--- a/pkg/backend/nvme_controller_validate.go
+++ b/pkg/backend/nvme_controller_validate.go
@@ -3,3 +3,71 @@
 
 // Package backend implememnts the BackEnd APIs (network facing) of the storage Server
 package backend
+
+import (
+	"go.einride.tech/aip/fieldbehavior"
+	"go.einride.tech/aip/resourceid"
+	"go.einride.tech/aip/resourcename"
+
+	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+)
+
+func (s *Server) validateCreateNvmeRemoteControllerRequest(in *pb.CreateNvmeRemoteControllerRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.NvmeRemoteControllerId != "" {
+		if err := resourceid.ValidateUserSettable(in.NvmeRemoteControllerId); err != nil {
+			return err
+		}
+	}
+	// TODO: validate also: block_size, blocks_count, uuid, filename
+	return nil
+}
+
+func (s *Server) validateDeleteNvmeRemoteControllerRequest(in *pb.DeleteNvmeRemoteControllerRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateResetNvmeRemoteControllerRequest(in *pb.ResetNvmeRemoteControllerRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateUpdateNvmeRemoteControllerRequest(in *pb.UpdateNvmeRemoteControllerRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.NvmeRemoteController.Name)
+}
+
+func (s *Server) validateGetNvmeRemoteControllerRequest(in *pb.GetNvmeRemoteControllerRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateStatsNvmeRemoteControllerRequest(in *pb.StatsNvmeRemoteControllerRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}

--- a/pkg/backend/nvme_controller_validate.go
+++ b/pkg/backend/nvme_controller_validate.go
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2023 Dell Inc, or its subsidiaries.
+
+// Package backend implememnts the BackEnd APIs (network facing) of the storage Server
+package backend

--- a/pkg/backend/nvme_path_validate.go
+++ b/pkg/backend/nvme_path_validate.go
@@ -3,3 +3,86 @@
 
 // Package backend implememnts the BackEnd APIs (network facing) of the storage Server
 package backend
+
+import (
+	"go.einride.tech/aip/fieldbehavior"
+	"go.einride.tech/aip/resourceid"
+	"go.einride.tech/aip/resourcename"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+)
+
+func (s *Server) validateCreateNvmePathRequest(in *pb.CreateNvmePathRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.NvmePathId != "" {
+		if err := resourceid.ValidateUserSettable(in.NvmePathId); err != nil {
+			return err
+		}
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	if err := resourcename.Validate(in.NvmePath.ControllerNameRef); err != nil {
+		return err
+	}
+	// validate Fabrics and Type coordinated
+	switch in.NvmePath.Trtype {
+	case pb.NvmeTransportType_NVME_TRANSPORT_PCIE:
+		if in.NvmePath.Fabrics != nil {
+			err := status.Errorf(codes.InvalidArgument, "fabrics field is not allowed for pcie transport")
+			return err
+		}
+	case pb.NvmeTransportType_NVME_TRANSPORT_TCP:
+		fallthrough
+	case pb.NvmeTransportType_NVME_TRANSPORT_RDMA:
+		if in.NvmePath.Fabrics == nil {
+			err := status.Errorf(codes.InvalidArgument, "missing required field for fabrics transports: fabrics")
+			return err
+		}
+	default:
+		err := status.Errorf(codes.InvalidArgument, "not supported transport type: %v", in.NvmePath.Trtype)
+		return err
+	}
+	return nil
+}
+
+func (s *Server) validateDeleteNvmePathRequest(in *pb.DeleteNvmePathRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateUpdateNvmePathRequest(in *pb.UpdateNvmePathRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.NvmePath.Name)
+}
+
+func (s *Server) validateGetNvmePathRequest(in *pb.GetNvmePathRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateStatsNvmePathRequest(in *pb.StatsNvmePathRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}

--- a/pkg/backend/nvme_path_validate.go
+++ b/pkg/backend/nvme_path_validate.go
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2023 Dell Inc, or its subsidiaries.
+
+// Package backend implememnts the BackEnd APIs (network facing) of the storage Server
+package backend

--- a/pkg/frontend/blk.go
+++ b/pkg/frontend/blk.go
@@ -20,7 +20,6 @@ import (
 	"go.einride.tech/aip/fieldbehavior"
 	"go.einride.tech/aip/fieldmask"
 	"go.einride.tech/aip/resourceid"
-	"go.einride.tech/aip/resourcename"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -74,24 +73,14 @@ func (v vhostUserBlkTransport) verifyTransportSpecificParams(virtioBlk *pb.Virti
 // CreateVirtioBlk creates a Virtio block device
 func (s *Server) CreateVirtioBlk(_ context.Context, in *pb.CreateVirtioBlkRequest) (*pb.VirtioBlk, error) {
 	log.Printf("CreateVirtioBlk: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.VirtioBlk.VolumeNameRef); err != nil {
+	// check input correctness
+	if err := s.validateCreateVirtioBlkRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
 	// see https://google.aip.dev/133#user-specified-ids
 	resourceID := resourceid.NewSystemGenerated()
 	if in.VirtioBlkId != "" {
-		err := resourceid.ValidateUserSettable(in.VirtioBlkId)
-		if err != nil {
-			log.Printf("error: %v", err)
-			return nil, err
-		}
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.VirtioBlkId, in.VirtioBlk.Name)
 		resourceID = in.VirtioBlkId
 	}
@@ -131,13 +120,8 @@ func (s *Server) CreateVirtioBlk(_ context.Context, in *pb.CreateVirtioBlkReques
 // DeleteVirtioBlk deletes a Virtio block device
 func (s *Server) DeleteVirtioBlk(_ context.Context, in *pb.DeleteVirtioBlkRequest) (*emptypb.Empty, error) {
 	log.Printf("DeleteVirtioBlk: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateDeleteVirtioBlkRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -177,18 +161,8 @@ func (s *Server) DeleteVirtioBlk(_ context.Context, in *pb.DeleteVirtioBlkReques
 // UpdateVirtioBlk updates a Virtio block device
 func (s *Server) UpdateVirtioBlk(_ context.Context, in *pb.UpdateVirtioBlkRequest) (*pb.VirtioBlk, error) {
 	log.Printf("UpdateVirtioBlk: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.VirtioBlk.Name); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.VirtioBlk.VolumeNameRef); err != nil {
+	// check input correctness
+	if err := s.validateUpdateVirtioBlkRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -260,13 +234,8 @@ func (s *Server) ListVirtioBlks(_ context.Context, in *pb.ListVirtioBlksRequest)
 // GetVirtioBlk gets a Virtio block device
 func (s *Server) GetVirtioBlk(_ context.Context, in *pb.GetVirtioBlkRequest) (*pb.VirtioBlk, error) {
 	log.Printf("GetVirtioBlk: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateGetVirtioBlkRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -306,13 +275,8 @@ func (s *Server) GetVirtioBlk(_ context.Context, in *pb.GetVirtioBlkRequest) (*p
 // StatsVirtioBlk gets a Virtio block device stats
 func (s *Server) StatsVirtioBlk(_ context.Context, in *pb.StatsVirtioBlkRequest) (*pb.StatsVirtioBlkResponse, error) {
 	log.Printf("StatsVirtioBlk: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateStatsVirtioBlkRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}

--- a/pkg/frontend/blk_validate.go
+++ b/pkg/frontend/blk_validate.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2023 Dell Inc, or its subsidiaries.
+
+// Package frontend implememnts the FrontEnd APIs (host facing) of the storage Server
+package frontend
+
+import (
+	"go.einride.tech/aip/fieldbehavior"
+	"go.einride.tech/aip/resourceid"
+	"go.einride.tech/aip/resourcename"
+
+	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+)
+
+func (s *Server) validateCreateVirtioBlkRequest(in *pb.CreateVirtioBlkRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	if err := resourcename.Validate(in.VirtioBlk.VolumeNameRef); err != nil {
+		return err
+	}
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.VirtioBlkId != "" {
+		if err := resourceid.ValidateUserSettable(in.VirtioBlkId); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Server) validateDeleteVirtioBlkRequest(in *pb.DeleteVirtioBlkRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateUpdateVirtioBlkRequest(in *pb.UpdateVirtioBlkRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	if err := resourcename.Validate(in.VirtioBlk.VolumeNameRef); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.VirtioBlk.Name)
+}
+
+func (s *Server) validateGetVirtioBlkRequest(in *pb.GetVirtioBlkRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateStatsVirtioBlkRequest(in *pb.StatsVirtioBlkRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}

--- a/pkg/frontend/nvme_controller.go
+++ b/pkg/frontend/nvme_controller.go
@@ -22,7 +22,6 @@ import (
 	"go.einride.tech/aip/fieldbehavior"
 	"go.einride.tech/aip/fieldmask"
 	"go.einride.tech/aip/resourceid"
-	"go.einride.tech/aip/resourcename"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -91,24 +90,14 @@ func (c *tcpSubsystemListener) Params(_ *pb.NvmeController, nqn string) spdk.Nvm
 // CreateNvmeController creates an Nvme controller
 func (s *Server) CreateNvmeController(_ context.Context, in *pb.CreateNvmeControllerRequest) (*pb.NvmeController, error) {
 	log.Printf("Received from client: %v", in.NvmeController)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.GetParent()); err != nil {
+	// check input correctness
+	if err := s.validateCreateNvmeControllerRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
 	// see https://google.aip.dev/133#user-specified-ids
 	resourceID := resourceid.NewSystemGenerated()
 	if in.NvmeControllerId != "" {
-		err := resourceid.ValidateUserSettable(in.NvmeControllerId)
-		if err != nil {
-			log.Printf("error: %v", err)
-			return nil, err
-		}
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvmeControllerId, in.NvmeController.Name)
 		resourceID = in.NvmeControllerId
 	}
@@ -151,13 +140,8 @@ func (s *Server) CreateNvmeController(_ context.Context, in *pb.CreateNvmeContro
 // DeleteNvmeController deletes an Nvme controller
 func (s *Server) DeleteNvmeController(_ context.Context, in *pb.DeleteNvmeControllerRequest) (*emptypb.Empty, error) {
 	log.Printf("Received from client: %v", in.Name)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateDeleteNvmeControllerRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -200,13 +184,8 @@ func (s *Server) DeleteNvmeController(_ context.Context, in *pb.DeleteNvmeContro
 // UpdateNvmeController updates an Nvme controller
 func (s *Server) UpdateNvmeController(_ context.Context, in *pb.UpdateNvmeControllerRequest) (*pb.NvmeController, error) {
 	log.Printf("UpdateNvmeController: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.NvmeController.Name); err != nil {
+	// check input correctness
+	if err := s.validateUpdateNvmeControllerRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -255,13 +234,8 @@ func (s *Server) ListNvmeControllers(_ context.Context, in *pb.ListNvmeControlle
 // GetNvmeController gets an Nvme controller
 func (s *Server) GetNvmeController(_ context.Context, in *pb.GetNvmeControllerRequest) (*pb.NvmeController, error) {
 	log.Printf("Received from client: %v", in.Name)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateGetNvmeControllerRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -278,17 +252,11 @@ func (s *Server) GetNvmeController(_ context.Context, in *pb.GetNvmeControllerRe
 // StatsNvmeController gets an Nvme controller stats
 func (s *Server) StatsNvmeController(_ context.Context, in *pb.StatsNvmeControllerRequest) (*pb.StatsNvmeControllerResponse, error) {
 	log.Printf("StatsNvmeController: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+	// check input correctness
+	if err := s.validateStatsNvmeControllerRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-
 	// fetch object from the database
 	ctrlr, ok := s.Nvme.Controllers[in.Name]
 	if !ok {

--- a/pkg/frontend/nvme_controller_validate.go
+++ b/pkg/frontend/nvme_controller_validate.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2023 Dell Inc, or its subsidiaries.
+
+// Package frontend implememnts the FrontEnd APIs (host facing) of the storage Server
+package frontend
+
+import (
+	"go.einride.tech/aip/fieldbehavior"
+	"go.einride.tech/aip/resourceid"
+	"go.einride.tech/aip/resourcename"
+
+	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+)
+
+func (s *Server) validateCreateNvmeControllerRequest(in *pb.CreateNvmeControllerRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.NvmeControllerId != "" {
+		if err := resourceid.ValidateUserSettable(in.NvmeControllerId); err != nil {
+			return err
+		}
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Parent)
+}
+
+func (s *Server) validateDeleteNvmeControllerRequest(in *pb.DeleteNvmeControllerRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateUpdateNvmeControllerRequest(in *pb.UpdateNvmeControllerRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.NvmeController.Name)
+}
+
+func (s *Server) validateGetNvmeControllerRequest(in *pb.GetNvmeControllerRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateStatsNvmeControllerRequest(in *pb.StatsNvmeControllerRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}

--- a/pkg/frontend/nvme_namespace.go
+++ b/pkg/frontend/nvme_namespace.go
@@ -20,7 +20,6 @@ import (
 	"go.einride.tech/aip/fieldbehavior"
 	"go.einride.tech/aip/fieldmask"
 	"go.einride.tech/aip/resourceid"
-	"go.einride.tech/aip/resourcename"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -35,30 +34,14 @@ func sortNvmeNamespaces(namespaces []*pb.NvmeNamespace) {
 // CreateNvmeNamespace creates an Nvme namespace
 func (s *Server) CreateNvmeNamespace(_ context.Context, in *pb.CreateNvmeNamespaceRequest) (*pb.NvmeNamespace, error) {
 	log.Printf("CreateNvmeNamespace: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// check input parameters validity
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Parent); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.NvmeNamespace.Spec.VolumeNameRef); err != nil {
+	// check input correctness
+	if err := s.validateCreateNvmeNamespaceRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
 	// see https://google.aip.dev/133#user-specified-ids
 	resourceID := resourceid.NewSystemGenerated()
 	if in.NvmeNamespaceId != "" {
-		err := resourceid.ValidateUserSettable(in.NvmeNamespaceId)
-		if err != nil {
-			log.Printf("error: %v", err)
-			return nil, err
-		}
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvmeNamespaceId, in.NvmeNamespace.Name)
 		resourceID = in.NvmeNamespaceId
 	}
@@ -109,13 +92,8 @@ func (s *Server) CreateNvmeNamespace(_ context.Context, in *pb.CreateNvmeNamespa
 // DeleteNvmeNamespace deletes an Nvme namespace
 func (s *Server) DeleteNvmeNamespace(_ context.Context, in *pb.DeleteNvmeNamespaceRequest) (*emptypb.Empty, error) {
 	log.Printf("DeleteNvmeNamespace: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateDeleteNvmeNamespaceRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -160,18 +138,8 @@ func (s *Server) DeleteNvmeNamespace(_ context.Context, in *pb.DeleteNvmeNamespa
 // UpdateNvmeNamespace updates an Nvme namespace
 func (s *Server) UpdateNvmeNamespace(_ context.Context, in *pb.UpdateNvmeNamespaceRequest) (*pb.NvmeNamespace, error) {
 	log.Printf("UpdateNvmeNamespace: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.NvmeNamespace.Name); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.NvmeNamespace.Spec.VolumeNameRef); err != nil {
+	// check input correctness
+	if err := s.validateUpdateNvmeNamespaceRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -260,13 +228,8 @@ func (s *Server) ListNvmeNamespaces(_ context.Context, in *pb.ListNvmeNamespaces
 // GetNvmeNamespace gets an Nvme namespace
 func (s *Server) GetNvmeNamespace(_ context.Context, in *pb.GetNvmeNamespaceRequest) (*pb.NvmeNamespace, error) {
 	log.Printf("GetNvmeNamespace: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateGetNvmeNamespaceRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -322,13 +285,8 @@ func (s *Server) GetNvmeNamespace(_ context.Context, in *pb.GetNvmeNamespaceRequ
 // StatsNvmeNamespace gets an Nvme namespace stats
 func (s *Server) StatsNvmeNamespace(_ context.Context, in *pb.StatsNvmeNamespaceRequest) (*pb.StatsNvmeNamespaceResponse, error) {
 	log.Printf("StatsNvmeNamespace: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateStatsNvmeNamespaceRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}

--- a/pkg/frontend/nvme_namespace_validate.go
+++ b/pkg/frontend/nvme_namespace_validate.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2023 Dell Inc, or its subsidiaries.
+
+// Package frontend implememnts the FrontEnd APIs (host facing) of the storage Server
+package frontend
+
+import (
+	"go.einride.tech/aip/fieldbehavior"
+	"go.einride.tech/aip/resourceid"
+	"go.einride.tech/aip/resourcename"
+
+	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+)
+
+func (s *Server) validateCreateNvmeNamespaceRequest(in *pb.CreateNvmeNamespaceRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.NvmeNamespaceId != "" {
+		if err := resourceid.ValidateUserSettable(in.NvmeNamespaceId); err != nil {
+			return err
+		}
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	if err := resourcename.Validate(in.Parent); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.NvmeNamespace.Spec.VolumeNameRef)
+}
+
+func (s *Server) validateDeleteNvmeNamespaceRequest(in *pb.DeleteNvmeNamespaceRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateUpdateNvmeNamespaceRequest(in *pb.UpdateNvmeNamespaceRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	if err := resourcename.Validate(in.NvmeNamespace.Spec.VolumeNameRef); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.NvmeNamespace.Name)
+}
+
+func (s *Server) validateGetNvmeNamespaceRequest(in *pb.GetNvmeNamespaceRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateStatsNvmeNamespaceRequest(in *pb.StatsNvmeNamespaceRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}

--- a/pkg/frontend/nvme_subsystem.go
+++ b/pkg/frontend/nvme_subsystem.go
@@ -20,7 +20,6 @@ import (
 	"go.einride.tech/aip/fieldbehavior"
 	"go.einride.tech/aip/fieldmask"
 	"go.einride.tech/aip/resourceid"
-	"go.einride.tech/aip/resourcename"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -35,19 +34,14 @@ func sortNvmeSubsystems(subsystems []*pb.NvmeSubsystem) {
 // CreateNvmeSubsystem creates an Nvme Subsystem
 func (s *Server) CreateNvmeSubsystem(_ context.Context, in *pb.CreateNvmeSubsystemRequest) (*pb.NvmeSubsystem, error) {
 	log.Printf("CreateNvmeSubsystem: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+	// check input correctness
+	if err := s.validateCreateNvmeSubsystemRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
 	// see https://google.aip.dev/133#user-specified-ids
 	resourceID := resourceid.NewSystemGenerated()
 	if in.NvmeSubsystemId != "" {
-		err := resourceid.ValidateUserSettable(in.NvmeSubsystemId)
-		if err != nil {
-			log.Printf("error: %v", err)
-			return nil, err
-		}
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvmeSubsystemId, in.NvmeSubsystem.Name)
 		resourceID = in.NvmeSubsystemId
 	}
@@ -102,13 +96,8 @@ func (s *Server) CreateNvmeSubsystem(_ context.Context, in *pb.CreateNvmeSubsyst
 // DeleteNvmeSubsystem deletes an Nvme Subsystem
 func (s *Server) DeleteNvmeSubsystem(_ context.Context, in *pb.DeleteNvmeSubsystemRequest) (*emptypb.Empty, error) {
 	log.Printf("DeleteNvmeSubsystem: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateDeleteNvmeSubsystemRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -144,13 +133,8 @@ func (s *Server) DeleteNvmeSubsystem(_ context.Context, in *pb.DeleteNvmeSubsyst
 // UpdateNvmeSubsystem updates an Nvme Subsystem
 func (s *Server) UpdateNvmeSubsystem(_ context.Context, in *pb.UpdateNvmeSubsystemRequest) (*pb.NvmeSubsystem, error) {
 	log.Printf("UpdateNvmeSubsystem: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.NvmeSubsystem.Name); err != nil {
+	// check input correctness
+	if err := s.validateUpdateNvmeSubsystemRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -214,13 +198,8 @@ func (s *Server) ListNvmeSubsystems(_ context.Context, in *pb.ListNvmeSubsystems
 // GetNvmeSubsystem gets Nvme Subsystems
 func (s *Server) GetNvmeSubsystem(_ context.Context, in *pb.GetNvmeSubsystemRequest) (*pb.NvmeSubsystem, error) {
 	log.Printf("GetNvmeSubsystem: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateGetNvmeSubsystemRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}
@@ -254,13 +233,8 @@ func (s *Server) GetNvmeSubsystem(_ context.Context, in *pb.GetNvmeSubsystemRequ
 // StatsNvmeSubsystem gets Nvme Subsystem stats
 func (s *Server) StatsNvmeSubsystem(_ context.Context, in *pb.StatsNvmeSubsystemRequest) (*pb.StatsNvmeSubsystemResponse, error) {
 	log.Printf("StatsNvmeSubsystem: Received from client: %v", in)
-	// check required fields
-	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
-		log.Printf("error: %v", err)
-		return nil, err
-	}
-	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
-	if err := resourcename.Validate(in.Name); err != nil {
+	// check input correctness
+	if err := s.validateStatsNvmeSubsystemRequest(in); err != nil {
 		log.Printf("error: %v", err)
 		return nil, err
 	}

--- a/pkg/frontend/nvme_subsystem_test.go
+++ b/pkg/frontend/nvme_subsystem_test.go
@@ -8,6 +8,7 @@ package frontend
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"google.golang.org/protobuf/proto"
@@ -150,6 +151,54 @@ func TestFrontEnd_CreateNvmeSubsystem(t *testing.T) {
 			codes.Unknown,
 			"missing required field: nvme_subsystem",
 			false,
+		},
+		"too long nqn field": {
+			id: testControllerID,
+			in: &pb.NvmeSubsystem{
+				Name: testSubsystemName,
+				Spec: &pb.NvmeSubsystemSpec{
+					Nqn:          strings.Repeat("a", 224),
+					SerialNumber: strings.Repeat("b", 20),
+					ModelNumber:  strings.Repeat("c", 40),
+				},
+			},
+			out:     nil,
+			spdk:    []string{},
+			errCode: codes.InvalidArgument,
+			errMsg:  fmt.Sprintf("Nqn value (%s) is too long, have to be between 1 and %d", strings.Repeat("a", 224), 223),
+			exist:   false,
+		},
+		"too long model field": {
+			id: testControllerID,
+			in: &pb.NvmeSubsystem{
+				Name: testSubsystemName,
+				Spec: &pb.NvmeSubsystemSpec{
+					Nqn:          strings.Repeat("a", 223),
+					SerialNumber: strings.Repeat("b", 20),
+					ModelNumber:  strings.Repeat("c", 41),
+				},
+			},
+			out:     nil,
+			spdk:    []string{},
+			errCode: codes.InvalidArgument,
+			errMsg:  fmt.Sprintf("ModelNumber value (%s) is too long, have to be between 1 and %d", strings.Repeat("c", 41), 40),
+			exist:   false,
+		},
+		"too long serial field": {
+			id: testControllerID,
+			in: &pb.NvmeSubsystem{
+				Name: testSubsystemName,
+				Spec: &pb.NvmeSubsystemSpec{
+					Nqn:          strings.Repeat("a", 223),
+					SerialNumber: strings.Repeat("b", 21),
+					ModelNumber:  strings.Repeat("c", 40),
+				},
+			},
+			out:     nil,
+			spdk:    []string{},
+			errCode: codes.InvalidArgument,
+			errMsg:  fmt.Sprintf("SerialNumber value (%s) is too long, have to be between 1 and %d", strings.Repeat("b", 21), 20),
+			exist:   false,
 		},
 	}
 

--- a/pkg/frontend/nvme_subsystem_validate.go
+++ b/pkg/frontend/nvme_subsystem_validate.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2023 Dell Inc, or its subsidiaries.
+
+// Package frontend implememnts the FrontEnd APIs (host facing) of the storage Server
+package frontend
+
+import (
+	"fmt"
+
+	"go.einride.tech/aip/fieldbehavior"
+	"go.einride.tech/aip/resourceid"
+	"go.einride.tech/aip/resourcename"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+)
+
+func (s *Server) validateCreateNvmeSubsystemRequest(in *pb.CreateNvmeSubsystemRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.NvmeSubsystemId != "" {
+		if err := resourceid.ValidateUserSettable(in.NvmeSubsystemId); err != nil {
+			return err
+		}
+	}
+	// check Nqn length
+	if len(in.NvmeSubsystem.Spec.Nqn) > 223 {
+		msg := fmt.Sprintf("Nqn value (%s) is too long, have to be between 1 and 223", in.NvmeSubsystem.Spec.Nqn)
+		return status.Errorf(codes.InvalidArgument, msg)
+	}
+	// check SerialNumber length
+	if len(in.NvmeSubsystem.Spec.SerialNumber) > 20 {
+		msg := fmt.Sprintf("SerialNumber value (%s) is too long, have to be between 1 and 20", in.NvmeSubsystem.Spec.SerialNumber)
+		return status.Errorf(codes.InvalidArgument, msg)
+	}
+	// check ModelNumber length
+	if len(in.NvmeSubsystem.Spec.ModelNumber) > 40 {
+		msg := fmt.Sprintf("ModelNumber value (%s) is too long, have to be between 1 and 40", in.NvmeSubsystem.Spec.ModelNumber)
+		return status.Errorf(codes.InvalidArgument, msg)
+	}
+	// TODO: check in.NvmeSubsystem.Spec.Nqn validity with regexp
+	return nil
+}
+
+func (s *Server) validateDeleteNvmeSubsystemRequest(in *pb.DeleteNvmeSubsystemRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateUpdateNvmeSubsystemRequest(in *pb.UpdateNvmeSubsystemRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.NvmeSubsystem.Name)
+}
+
+func (s *Server) validateGetNvmeSubsystemRequest(in *pb.GetNvmeSubsystemRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateStatsNvmeSubsystemRequest(in *pb.StatsNvmeSubsystemRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}

--- a/pkg/frontend/scsi_validate.go
+++ b/pkg/frontend/scsi_validate.go
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2023 Dell Inc, or its subsidiaries.
+
+// Package frontend implememnts the FrontEnd APIs (host facing) of the storage Server
+package frontend

--- a/pkg/middleend/encryption_validate.go
+++ b/pkg/middleend/encryption_validate.go
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2023 Dell Inc, or its subsidiaries.
+
+// Package middleend implememnts the MiddleEnd APIs (service) of the storage Server
+package middleend

--- a/pkg/middleend/encryption_validate.go
+++ b/pkg/middleend/encryption_validate.go
@@ -3,3 +3,92 @@
 
 // Package middleend implememnts the MiddleEnd APIs (service) of the storage Server
 package middleend
+
+import (
+	"fmt"
+
+	"go.einride.tech/aip/fieldbehavior"
+	"go.einride.tech/aip/resourceid"
+	"go.einride.tech/aip/resourcename"
+
+	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+)
+
+func (s *Server) validateCreateEncryptedVolumeRequest(in *pb.CreateEncryptedVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	if err := resourcename.Validate(in.EncryptedVolume.VolumeNameRef); err != nil {
+		return err
+	}
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.EncryptedVolumeId != "" {
+		if err := resourceid.ValidateUserSettable(in.EncryptedVolumeId); err != nil {
+			return err
+		}
+	}
+	// TODO: validate also: block_size, blocks_count, uuid, filename
+	return nil
+}
+
+func (s *Server) validateDeleteEncryptedVolumeRequest(in *pb.DeleteEncryptedVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateUpdateEncryptedVolumeRequest(in *pb.UpdateEncryptedVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	if err := resourcename.Validate(in.EncryptedVolume.VolumeNameRef); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.EncryptedVolume.Name)
+}
+
+func (s *Server) validateGetEncryptedVolumeRequest(in *pb.GetEncryptedVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateStatsEncryptedVolumeRequest(in *pb.StatsEncryptedVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) verifyEncryptedVolume(volume *pb.EncryptedVolume) error {
+	keyLengthInBits := len(volume.Key) * 8
+	expectedKeyLengthInBits := 0
+	switch {
+	case volume.Cipher == pb.EncryptionType_ENCRYPTION_TYPE_AES_XTS_256:
+		expectedKeyLengthInBits = 512
+	case volume.Cipher == pb.EncryptionType_ENCRYPTION_TYPE_AES_XTS_128:
+		expectedKeyLengthInBits = 256
+	default:
+		return fmt.Errorf("only AES_XTS_256 and AES_XTS_128 are supported")
+	}
+
+	if keyLengthInBits != expectedKeyLengthInBits {
+		return fmt.Errorf("expected key size %vb, provided size %vb",
+			expectedKeyLengthInBits, keyLengthInBits)
+	}
+
+	return nil
+}

--- a/pkg/middleend/qos_validate.go
+++ b/pkg/middleend/qos_validate.go
@@ -3,3 +3,109 @@
 
 // Package middleend implememnts the MiddleEnd APIs (service) of the storage Server
 package middleend
+
+import (
+	"fmt"
+
+	"go.einride.tech/aip/fieldbehavior"
+	"go.einride.tech/aip/resourceid"
+	"go.einride.tech/aip/resourcename"
+
+	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
+)
+
+func (s *Server) validateCreateQosVolumeRequest(in *pb.CreateQosVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.QosVolumeId != "" {
+		if err := resourceid.ValidateUserSettable(in.QosVolumeId); err != nil {
+			return err
+		}
+	}
+	// TODO: validate also: block_size, blocks_count, uuid, filename
+	return nil
+}
+
+func (s *Server) validateDeleteQosVolumeRequest(in *pb.DeleteQosVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateUpdateQosVolumeRequest(in *pb.UpdateQosVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	// TODO: return resourcename.Validate(in.QosVolume.Name)
+	return nil
+}
+
+func (s *Server) validateGetQosVolumeRequest(in *pb.GetQosVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) validateStatsQosVolumeRequest(in *pb.StatsQosVolumeRequest) error {
+	// check required fields
+	if err := fieldbehavior.ValidateRequiredFields(in); err != nil {
+		return err
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	return resourcename.Validate(in.Name)
+}
+
+func (s *Server) verifyQosVolume(volume *pb.QosVolume) error {
+	if volume.Name == "" {
+		return fmt.Errorf("QoS volume name cannot be empty")
+	}
+	// Validate that a resource name conforms to the restrictions outlined in AIP-122.
+	if err := resourcename.Validate(volume.Name); err != nil {
+		return err
+	}
+
+	if volume.Limits.Min != nil {
+		return fmt.Errorf("QoS volume min_limit is not supported")
+	}
+	if volume.Limits.Max.RdIopsKiops != 0 {
+		return fmt.Errorf("QoS volume max_limit rd_iops_kiops is not supported")
+	}
+	if volume.Limits.Max.WrIopsKiops != 0 {
+		return fmt.Errorf("QoS volume max_limit wr_iops_kiops is not supported")
+	}
+
+	if volume.Limits.Max.RdBandwidthMbs == 0 &&
+		volume.Limits.Max.WrBandwidthMbs == 0 &&
+		volume.Limits.Max.RwBandwidthMbs == 0 &&
+		volume.Limits.Max.RdIopsKiops == 0 &&
+		volume.Limits.Max.WrIopsKiops == 0 &&
+		volume.Limits.Max.RwIopsKiops == 0 {
+		return fmt.Errorf("QoS volume max_limit should set limit")
+	}
+
+	if volume.Limits.Max.RwIopsKiops < 0 {
+		return fmt.Errorf("QoS volume max_limit rw_iops_kiops cannot be negative")
+	}
+	if volume.Limits.Max.RdBandwidthMbs < 0 {
+		return fmt.Errorf("QoS volume max_limit rd_bandwidth_mbs cannot be negative")
+	}
+	if volume.Limits.Max.WrBandwidthMbs < 0 {
+		return fmt.Errorf("QoS volume max_limit wr_bandwidth_mbs cannot be negative")
+	}
+	if volume.Limits.Max.RwBandwidthMbs < 0 {
+		return fmt.Errorf("QoS volume max_limit rw_bandwidth_mbs cannot be negative")
+	}
+
+	return nil
+}

--- a/pkg/middleend/qos_validate.go
+++ b/pkg/middleend/qos_validate.go
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2023 Dell Inc, or its subsidiaries.
+
+// Package middleend implememnts the MiddleEnd APIs (service) of the storage Server
+package middleend


### PR DESCRIPTION
- refactor(frontend): split validate logic to a new file
- refactor(backend): split validate logic to a new file
- refactor(middleend): split validate logic to a new file
- test(nvme): check nqn, model and serial
- fix(backend): add missing UpdateNvmeRemoteController

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
