### PR TITLE
fix(psk): change PSK temp key file location

### DIFF
--- a/pkg/backend/nvme_path.go
+++ b/pkg/backend/nvme_path.go
@@ -295,7 +295,7 @@ func (s *Server) numberOfPathsForController(controllerName string) int {
 }
 
 func (s *Server) keyToTemporaryFile(pskKey []byte) (string, error) {
-	keyFile, err := s.psk.createTempFile("", "opikey")
+	keyFile, err := s.psk.createTempFile("/var/tmp", "opikey")
 	if err != nil {
 		log.Printf("error: failed to create file for key: %v", err)
 		return "", status.Error(codes.Internal, "failed to handle key")


### PR DESCRIPTION
Fixes #677
because in compose we map /var/tmp and not /tmp folder