### PR TITLE
feat: vfiouser transport created by default

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,7 +61,7 @@ func main() {
 	flag.StringVar(&qmpAddress, "qmp_addr", "127.0.0.1:5555", "Points to QMP unix socket/tcp socket to interact with. Valid only with -kvm option")
 
 	var ctrlrDir string
-	flag.StringVar(&ctrlrDir, "ctrlr_dir", "", "Directory with created SPDK device unix sockets (-S option in SPDK). Valid only with -kvm option")
+	flag.StringVar(&ctrlrDir, "ctrlr_dir", "/var/tmp", "Directory with created SPDK device unix sockets (-S option in SPDK).")
 
 	var busesStr string
 	flag.StringVar(&busesStr, "buses", "", "QEMU PCI buses IDs separated by `:` to attach Nvme/virtio-blk devices on. e.g. \"pci.opi.0:pci.opi.1\". Valid only with -kvm option")
@@ -140,30 +140,23 @@ func runGrpcServer(grpcPort int, useKvm bool, store gokv.Store, spdkAddress, qmp
 	jsonRPC := spdk.NewClient(spdkAddress)
 	backendServer := backend.NewServer(jsonRPC, store)
 	middleendServer := middleend.NewServer(jsonRPC, store)
+	frontendServer := frontend.NewCustomizedServer(jsonRPC,
+		store,
+		map[pb.NvmeTransportType]frontend.NvmeTransport{
+			pb.NvmeTransportType_NVME_TRANSPORT_TCP:  frontend.NewNvmeTCPTransport(),
+			pb.NvmeTransportType_NVME_TRANSPORT_PCIE: kvm.NewNvmeVfiouserTransport(ctrlrDir),
+		},
+		frontend.NewVhostUserBlkTransport(),
+	)
 
 	if useKvm {
 		log.Println("Creating KVM server.")
-		frontendServer := frontend.NewCustomizedServer(jsonRPC,
-			store,
-			map[pb.NvmeTransportType]frontend.NvmeTransport{
-				pb.NvmeTransportType_NVME_TRANSPORT_TCP:  frontend.NewNvmeTCPTransport(),
-				pb.NvmeTransportType_NVME_TRANSPORT_PCIE: kvm.NewNvmeVfiouserTransport(ctrlrDir),
-			},
-			frontend.NewVhostUserBlkTransport(),
-		)
 		kvmServer := kvm.NewServer(frontendServer, qmpAddress, ctrlrDir, buses)
 
 		pb.RegisterFrontendNvmeServiceServer(s, kvmServer)
 		pb.RegisterFrontendVirtioBlkServiceServer(s, kvmServer)
 		pb.RegisterFrontendVirtioScsiServiceServer(s, kvmServer)
 	} else {
-		frontendServer := frontend.NewCustomizedServer(jsonRPC,
-			store,
-			map[pb.NvmeTransportType]frontend.NvmeTransport{
-				pb.NvmeTransportType_NVME_TRANSPORT_TCP: frontend.NewNvmeTCPTransport(),
-			},
-			frontend.NewVhostUserBlkTransport(),
-		)
 		pb.RegisterFrontendNvmeServiceServer(s, frontendServer)
 		pb.RegisterFrontendVirtioBlkServiceServer(s, frontendServer)
 		pb.RegisterFrontendVirtioScsiServiceServer(s, frontendServer)

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -105,5 +105,15 @@ grep "Total" log.txt
 "${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeController "{name : '//storage.opiproject.org/subsystems/subsystem2/controllers/controller2'}"
 "${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeSubsystem "{name : '//storage.opiproject.org/subsystems/subsystem2'}"
 
+# test vfiouser
+rm -f /var/tmp/subsystem3/{cntrl,bar0}
+mkdir -p /var/tmp/subsystem3
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNvmeSubsystem  "{nvme_subsystem_id:  'subsystem3',  nvme_subsystem  : {spec : {nqn: 'nqn.2022-09.io.spdk:opitest3', serial_number: 'myserial1', model_number: 'mymodel1', max_namespaces: 11} } }"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNvmeController "{nvme_controller_id: 'controller3', parent: '//storage.opiproject.org/subsystems/subsystem3', nvme_controller : {spec : {nvme_controller_id: 2, pcie_id : {physical_function : 0, virtual_function : 0, port_id: 0}, max_nsq:5, max_ncq:5, 'trtype': 'NVME_TRANSPORT_PCIE' } } }"
+
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeController "{name : '//storage.opiproject.org/subsystems/subsystem3/controllers/controller3'}"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeSubsystem "{name : '//storage.opiproject.org/subsystems/subsystem3'}"
+rm -rf /var/tmp/subsystem3
+
 # this is last line
 docker-compose ps -a


### PR DESCRIPTION
Run vfiouser transport by default when the bridge is started. At the moment, a dir for a controller should be created manually, if -kvm option is not used. We may consider moving the directory creation code from kvm server into vfiouser transport