### PR TITLE
feat(frontend): any as spdk params for nvme controller

### DIFF
--- a/pkg/frontend/transport.go
+++ b/pkg/frontend/transport.go
@@ -17,7 +17,7 @@ import (
 // NvmeTransport interface is used to provide SPDK call params to create/delete
 // Nvme controllers depending on used transport type.
 type NvmeTransport interface {
-	Params(ctrlr *pb.NvmeController, subsys *pb.NvmeSubsystem) (spdk.NvmfSubsystemAddListenerParams, error)
+	Params(ctrlr *pb.NvmeController, subsys *pb.NvmeSubsystem) (any, error)
 }
 
 // VirtioBlkTransport interface is used to provide SPDK call params to create/delete
@@ -34,7 +34,7 @@ func NewNvmeTCPTransport() NvmeTransport {
 	return &nvmeTCPTransport{}
 }
 
-func (c *nvmeTCPTransport) Params(ctrlr *pb.NvmeController, subsys *pb.NvmeSubsystem) (spdk.NvmfSubsystemAddListenerParams, error) {
+func (c *nvmeTCPTransport) Params(ctrlr *pb.NvmeController, subsys *pb.NvmeSubsystem) (any, error) {
 	result := spdk.NvmfSubsystemAddListenerParams{}
 	result.Nqn = subsys.Spec.Nqn
 	result.SecureChannel = len(subsys.Spec.Psk) > 0

--- a/pkg/frontend/transport_test.go
+++ b/pkg/frontend/transport_test.go
@@ -16,7 +16,7 @@ type stubNvmeTransport struct {
 	err error
 }
 
-func (t *stubNvmeTransport) Params(_ *pb.NvmeController, _ *pb.NvmeSubsystem) (spdk.NvmfSubsystemAddListenerParams, error) {
+func (t *stubNvmeTransport) Params(_ *pb.NvmeController, _ *pb.NvmeSubsystem) (any, error) {
 	return spdk.NvmfSubsystemAddListenerParams{}, t.err
 }
 

--- a/pkg/kvm/transport.go
+++ b/pkg/kvm/transport.go
@@ -38,7 +38,7 @@ func NewNvmeVfiouserTransport(ctrlrDir string) frontend.NvmeTransport {
 	}
 }
 
-func (c *nvmeVfiouserTransport) Params(ctrlr *pb.NvmeController, subsys *pb.NvmeSubsystem) (spdk.NvmfSubsystemAddListenerParams, error) {
+func (c *nvmeVfiouserTransport) Params(ctrlr *pb.NvmeController, subsys *pb.NvmeSubsystem) (any, error) {
 	pcieID := ctrlr.GetSpec().GetPcieId()
 	if pcieID.PortId.Value != 0 {
 		return spdk.NvmfSubsystemAddListenerParams{},


### PR DESCRIPTION
This is needed if any other bridge needs to pass its own parameters as a part of nvmf_subsystem_add_listener call.

For example https://github.com/opiproject/opi-intel-bridge/pull/398