### PR TITLE
fix(frontend): precede nvme parent collections with nvme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,17 +80,17 @@ on X86 management VM run
 docker run --network=host --rm -it namely/grpc-cli ls   --json_input --json_output 10.10.10.10:50051 -l
 docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 CreateNvmeSubsystem "{nvme_subsystem : {spec : {nqn: 'nqn.2022-09.io.spdk:opitest2', serial_number: 'myserial2', model_number: 'mymodel2', max_namespaces: 11} }, nvme_subsystem_id : 'subsystem2' }"
 docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 ListNvmeSubsystems "{}"
-docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 GetNvmeSubsystem "{name : 'subsystems/subsystem2'}"
-docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 CreateNvmeController "{parent: 'subsystems/subsystem2', nvme_controller : {spec : {nvme_controller_id: 2, pcie_id : {physical_function : 0, virtual_function : 0, port_id: 0}, max_nsq:5, max_ncq:5, 'trtype': 'NVME_TRANSPORT_TYPE_PCIE' } }, nvme_controller_id : 'controller1'}"
+docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 GetNvmeSubsystem "{name : 'nvmeSubsystems/subsystem2'}"
+docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 CreateNvmeController "{parent: 'nvmeSubsystems/subsystem2', nvme_controller : {spec : {nvme_controller_id: 2, pcie_id : {physical_function : 0, virtual_function : 0, port_id: 0}, max_nsq:5, max_ncq:5, 'trtype': 'NVME_TRANSPORT_TYPE_PCIE' } }, nvme_controller_id : 'controller1'}"
 docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 CreateNvmeSubsystem "{nvme_subsystem : {spec : {nqn: 'nqn.2022-09.io.spdk:opitest3', serial_number: 'myserial2', model_number: 'mymodel2', max_namespaces: 11} }, nvme_subsystem_id : 'subsystem3' }"
-docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 CreateNvmeController "{'parent':'subsystems/subsystem3','nvme_controller':{'spec':{'nvme_controller_id':2,'fabrics_id':{'traddr': '127.0.0.1', trsvcid: '4421', adrfam: 'NVME_ADDRESS_FAMILY_IPV4'}, 'max_nsq':5,'max_ncq':5, 'trtype': 'NVME_TRANSPORT_TYPE_TCP'}},'nvme_controller_id':'controller3'}"
-docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 ListNvmeControllers "{parent : 'subsystems/subsystem2'}"
-docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 GetNvmeController "{name : 'subsystems/subsystem2/controllers/controller1'}"
-docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 GetNvmeController "{name : 'subsystems/subsystem3/controllers/controller3'}"
-docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 CreateNvmeNamespace "{parent: 'subsystems/subsystem2', nvme_namespace : {spec : {volume_name_ref : 'Malloc0', 'host_nsid' : '10', uuid:{value : '1b4e28ba-2fa1-11d2-883f-b9a761bde3fb'}, nguid: '1b4e28ba-2fa1-11d2-883f-b9a761bde3fb', eui64: 1967554867335598546 } }, nvme_namespace_id: 'namespace1'}"
-docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 ListNvmeNamespaces "{parent : 'subsystems/subsystem2'}"
-docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 GetNvmeNamespace "{name : 'subsystems/subsystem2/namespaces/namespace1'}"
-docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 StatsNvmeNamespace "{name : 'subsystems/subsystem2/namespaces/namespace1'}"
+docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 CreateNvmeController "{'parent':'nvmeSubsystems/subsystem3','nvme_controller':{'spec':{'nvme_controller_id':2,'fabrics_id':{'traddr': '127.0.0.1', trsvcid: '4421', adrfam: 'NVME_ADDRESS_FAMILY_IPV4'}, 'max_nsq':5,'max_ncq':5, 'trtype': 'NVME_TRANSPORT_TYPE_TCP'}},'nvme_controller_id':'controller3'}"
+docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 ListNvmeControllers "{parent : 'nvmeSubsystems/subsystem2'}"
+docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 GetNvmeController "{name : 'nvmeSubsystems/subsystem2/nvmeControllers/controller1'}"
+docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 GetNvmeController "{name : 'nvmeSubsystems/subsystem3/nvmeControllers/controller3'}"
+docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 CreateNvmeNamespace "{parent: 'nvmeSubsystems/subsystem2', nvme_namespace : {spec : {volume_name_ref : 'Malloc0', 'host_nsid' : '10', uuid:{value : '1b4e28ba-2fa1-11d2-883f-b9a761bde3fb'}, nguid: '1b4e28ba-2fa1-11d2-883f-b9a761bde3fb', eui64: 1967554867335598546 } }, nvme_namespace_id: 'namespace1'}"
+docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 ListNvmeNamespaces "{parent : 'nvmeSubsystems/subsystem2'}"
+docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 GetNvmeNamespace "{name : 'nvmeSubsystems/subsystem2/nvmeNamespaces/namespace1'}"
+docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 StatsNvmeNamespace "{name : 'nvmeSubsystems/subsystem2/nvmeNamespaces/namespace1'}"
 docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 CreateNvmeRemoteController "{nvme_remote_controller : {multipath: 'NVME_MULTIPATH_MULTIPATH', tcp: {hdgst: false, ddgst: false}}, nvme_remote_controller_id: 'nvmetcp12'}"
 docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 ListNvmeRemoteControllers "{}"
 docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 GetNvmeRemoteController "{name: 'nvmeRemoteControllers/nvmetcp12'}"
@@ -104,11 +104,11 @@ docker run --network=host --rm -it namely/grpc-cli call --json_input --json_outp
 docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 GetNvmePath "{name: 'nvmeRemoteControllers/nvmetcp12/nvmePaths/nvmetcp12path0'}"
 docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 DeleteNvmePath "{name: 'nvmeRemoteControllers/nvmetcp12/nvmePaths/nvmetcp12path0'}"
 docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 DeleteNvmeRemoteController "{name: 'nvmeRemoteControllers/nvmetcp12'}"
-docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 DeleteNvmeNamespace "{name : 'subsystems/subsystem2/namespaces/namespace1'}"
-docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 DeleteNvmeController "{name : 'subsystems/subsystem2/controllers/controller1'}"
-docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 DeleteNvmeSubsystem "{name : 'subsystems/subsystem2'}"
-docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 DeleteNvmeController "{name : 'subsystems/subsystem3/controllers/controller3'}"
-docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 DeleteNvmeSubsystem "{name : 'subsystems/subsystem3'}"
+docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 DeleteNvmeNamespace "{name : 'nvmeSubsystems/subsystem2/nvmeNamespaces/namespace1'}"
+docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 DeleteNvmeController "{name : 'nvmeSubsystems/subsystem2/nvmeControllers/controller1'}"
+docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 DeleteNvmeSubsystem "{name : 'nvmeSubsystems/subsystem2'}"
+docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 DeleteNvmeController "{name : 'nvmeSubsystems/subsystem3/nvmeControllers/controller3'}"
+docker run --network=host --rm -it namely/grpc-cli call --json_input --json_output 10.10.10.10:50051 DeleteNvmeSubsystem "{name : 'nvmeSubsystems/subsystem3'}"
 ```
 
 ## Test SPDK is up
@@ -204,7 +204,7 @@ message PciEndpoint {
 Call remote method
 
 ```bash
-$ grpc_cli call --json_input --json_output opi-spdk-server:50051 DeleteNvmeController "{name : 'subsystems/subsystem2/controllers/controller1'}"
+$ grpc_cli call --json_input --json_output opi-spdk-server:50051 DeleteNvmeController "{name : 'nvmeSubsystems/subsystem2/nvmeControllers/controller1'}"
 connecting to opi-spdk-server:50051
 {}
 Rpc succeeded with OK status

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
     command: curl -qkL http://opi-spdk-server:8082/v1/inventory/1/inventory/2
 
   opi-spdk-client:
-    image: ghcr.io/opiproject/godpu:main@sha256:7946abc446ff19bc6107606d63f53b7ac9bb9b003b1e95ff4ef512ad0f0c0470
+    image: ghcr.io/opiproject/godpu:main@sha256:daabe608fc8c543e75369a2ec434616033011d27d901c62d7456f60a427f39f1
     networks:
       - opi
     depends_on:

--- a/pkg/frontend/nvme_controller_test.go
+++ b/pkg/frontend/nvme_controller_test.go
@@ -601,7 +601,7 @@ func TestFrontEnd_UpdateNvmeController(t *testing.T) {
 
 func TestFrontEnd_ListNvmeControllers(t *testing.T) {
 	t.Cleanup(checkGlobalTestProtoObjectsNotChanged(t, t.Name()))
-	secondControllerName := utils.ResourceIDToControllerName(testSubsystemName, "controller-test1")
+	secondControllerName := utils.ResourceIDToControllerName(testSubsystemID, "controller-test1")
 	tests := map[string]struct {
 		in      string
 		out     []*pb.NvmeController

--- a/pkg/utils/resource.go
+++ b/pkg/utils/resource.go
@@ -21,7 +21,7 @@ func ResourceIDToVolumeName(resourceID string) string {
 // ResourceIDToSubsystemName transforms subsystem resource ID to subsystem name
 func ResourceIDToSubsystemName(resourceID string) string {
 	return resourcename.Join(
-		"subsystems", resourceID,
+		"nvmeSubsystems", resourceID,
 	)
 }
 
@@ -29,8 +29,8 @@ func ResourceIDToSubsystemName(resourceID string) string {
 // resource ID to namespace name
 func ResourceIDToNamespaceName(subsysResourceID, ctrlrResourceID string) string {
 	return resourcename.Join(
-		"subsystems", subsysResourceID,
-		"namespaces", ctrlrResourceID,
+		"nvmeSubsystems", subsysResourceID,
+		"nvmeNamespaces", ctrlrResourceID,
 	)
 }
 
@@ -38,8 +38,8 @@ func ResourceIDToNamespaceName(subsysResourceID, ctrlrResourceID string) string 
 // resource ID to controller name
 func ResourceIDToControllerName(subsysResourceID, ctrlrResourceID string) string {
 	return resourcename.Join(
-		"subsystems", subsysResourceID,
-		"controllers", ctrlrResourceID,
+		"nvmeSubsystems", subsysResourceID,
+		"nvmeControllers", ctrlrResourceID,
 	)
 }
 
@@ -51,7 +51,7 @@ func GetSubsystemIDFromNvmeName(name string) string {
 			return ""
 		}
 
-		if segments[i] == "subsystems" {
+		if segments[i] == "nvmeSubsystems" {
 			return segments[i+1]
 		}
 	}

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -67,11 +67,11 @@ grep "Total" log.txt
 
 # test nvme
 "${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNvmeSubsystem  "{nvme_subsystem_id:  'subsystem1',  nvme_subsystem  : {spec : {nqn: 'nqn.2022-09.io.spdk:opitest1', serial_number: 'myserial1', model_number: 'mymodel1', max_namespaces: 11} } }"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNvmeController "{nvme_controller_id: 'controller1', parent: 'subsystems/subsystem1', nvme_controller : {spec : {nvme_controller_id: 2, 'fabrics_id':{'traddr': '${SPDK_IP}', trsvcid: '7777', adrfam: 'NVME_ADDRESS_FAMILY_IPV4'}, max_nsq:5, max_ncq:5, 'trtype': 'NVME_TRANSPORT_TYPE_TCP' } } }"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNvmeNamespace  "{nvme_namespace_id:  'namespace1',  parent: 'subsystems/subsystem1', nvme_namespace  : {spec : {volume_name_ref : 'Malloc1', host_nsid : 1 } } }"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNvmeSubsystem "{name : 'subsystems/subsystem1'}"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNvmeController "{name : 'subsystems/subsystem1/controllers/controller1'}"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNvmeNamespace "{name :  'subsystems/subsystem1/namespaces/namespace1'}"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNvmeController "{nvme_controller_id: 'controller1', parent: 'nvmeSubsystems/subsystem1', nvme_controller : {spec : {nvme_controller_id: 2, 'fabrics_id':{'traddr': '${SPDK_IP}', trsvcid: '7777', adrfam: 'NVME_ADDRESS_FAMILY_IPV4'}, max_nsq:5, max_ncq:5, 'trtype': 'NVME_TRANSPORT_TYPE_TCP' } } }"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNvmeNamespace  "{nvme_namespace_id:  'namespace1',  parent: 'nvmeSubsystems/subsystem1', nvme_namespace  : {spec : {volume_name_ref : 'Malloc1', host_nsid : 1 } } }"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNvmeSubsystem "{name : 'nvmeSubsystems/subsystem1'}"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNvmeController "{name : 'nvmeSubsystems/subsystem1/nvmeControllers/controller1'}"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNvmeNamespace "{name :  'nvmeSubsystems/subsystem1/nvmeNamespaces/namespace1'}"
 docker run --rm --network=host --privileged -v /dev/hugepages:/dev/hugepages ghcr.io/opiproject/spdk:main spdk_nvme_identify -r 'traddr:127.0.0.1 trtype:TCP adrfam:IPv4 trsvcid:7777 hostnqn:nqn.2014-08.org.nvmexpress:uuid:feb98abe-d51f-40c8-b348-2753f3571d3c'
 docker run --rm --network=host --privileged -v /dev/hugepages:/dev/hugepages ghcr.io/opiproject/spdk:main spdk_nvme_perf     -r 'traddr:127.0.0.1 trtype:TCP adrfam:IPv4 trsvcid:7777 subnqn:nqn.2022-09.io.spdk:opitest1 hostnqn:nqn.2014-08.org.nvmexpress:uuid:feb98abe-d51f-40c8-b348-2753f3571d3c' -c 0x1 -q 1 -o 4096 -w randread -t 10 | tee log.txt
 grep "Total" log.txt
@@ -80,24 +80,19 @@ grep "Total" log.txt
 "${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNvmeRemoteController "{name: 'nvmeRemoteControllers/nvmetcp12'}"
 "${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNvmePath "{name: 'nvmeRemoteControllers/nvmetcp12/nvmePaths/nvmetcp12path0'}"
 
-# check http gateway is responding on List commands
-curl -X GET -f "http://127.0.0.1:8082/v1/nvmeRemoteControllers" | jq '.nvmeRemoteControllers[0].name'
-curl -X GET -f "http://127.0.0.1:8082/v1/nvmeRemoteControllers/nvmetcp12/nvmePaths" | jq .nvmePaths[0].name
-curl -X GET -f "http://127.0.0.1:8082/v1/nvmeSubsystems" | jq .nvmeSubsystems[1].spec.nqn
-
 "${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmePath "{name: 'nvmeRemoteControllers/nvmetcp12/nvmePaths/nvmetcp12path0'}"
 "${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeRemoteController "{name: 'nvmeRemoteControllers/nvmetcp12'}"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeNamespace "{name : 'subsystems/subsystem1/namespaces/namespace1'}"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeController "{name : 'subsystems/subsystem1/controllers/controller1'}"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeSubsystem "{name : 'subsystems/subsystem1'}"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeNamespace "{name : 'nvmeSubsystems/subsystem1/nvmeNamespaces/namespace1'}"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeController "{name : 'nvmeSubsystems/subsystem1/nvmeControllers/controller1'}"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeSubsystem "{name : 'nvmeSubsystems/subsystem1'}"
 
 # test nvme with TLS
 "${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNvmeSubsystem  "{nvme_subsystem_id:  'subsystem2',  nvme_subsystem  : {spec : {nqn: 'nqn.2022-09.io.spdk:opitest2', serial_number: 'myserial2', model_number: 'mymodel2', max_namespaces: 22, hostnqn: 'nqn.2014-08.org.nvmexpress:uuid:feb98abe-d51f-40c8-b348-2753f3571d3c', psk: 'TlZNZVRMU2tleS0xOjAxOk1EQXhNVEl5TXpNME5EVTFOalkzTnpnNE9UbGhZV0ppWTJOa1pHVmxabVp3SkVpUTo='} } }"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNvmeController "{nvme_controller_id: 'controller2', parent: 'subsystems/subsystem2', nvme_controller : {spec : {nvme_controller_id: 22, 'fabrics_id':{'traddr': '${SPDK_IP}', trsvcid: '8888', adrfam: 'NVME_ADDRESS_FAMILY_IPV4'}, max_nsq:5, max_ncq:5, 'trtype': 'NVME_TRANSPORT_TYPE_TCP' } } }"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNvmeNamespace  "{nvme_namespace_id:  'namespace2',  parent: 'subsystems/subsystem2', nvme_namespace  : {spec : {volume_name_ref : 'Malloc1', host_nsid : 1 } } }"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNvmeSubsystem "{name : 'subsystems/subsystem2'}"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNvmeController "{name : 'subsystems/subsystem2/controllers/controller2'}"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNvmeNamespace "{name :  'subsystems/subsystem2/namespaces/namespace2'}"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNvmeController "{nvme_controller_id: 'controller2', parent: 'nvmeSubsystems/subsystem2', nvme_controller : {spec : {nvme_controller_id: 22, 'fabrics_id':{'traddr': '${SPDK_IP}', trsvcid: '8888', adrfam: 'NVME_ADDRESS_FAMILY_IPV4'}, max_nsq:5, max_ncq:5, 'trtype': 'NVME_TRANSPORT_TYPE_TCP' } } }"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 CreateNvmeNamespace  "{nvme_namespace_id:  'namespace2',  parent: 'nvmeSubsystems/subsystem2', nvme_namespace  : {spec : {volume_name_ref : 'Malloc1', host_nsid : 1 } } }"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNvmeSubsystem "{name : 'nvmeSubsystems/subsystem2'}"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNvmeController "{name : 'nvmeSubsystems/subsystem2/nvmeControllers/controller2'}"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNvmeNamespace "{name :  'nvmeSubsystems/subsystem2/nvmeNamespaces/namespace2'}"
 # docker run --rm --network=host --privileged -v /dev/hugepages:/dev/hugepages ghcr.io/opiproject/spdk:main spdk_nvme_identify -r 'traddr:127.0.0.1 trtype:TCP adrfam:IPv4 trsvcid:8888 hostnqn:nqn.2014-08.org.nvmexpress:uuid:feb98abe-d51f-40c8-b348-2753f3571d3c'
 docker run --rm --network=host --privileged -v /dev/hugepages:/dev/hugepages -v /tmp/opikey.txt:/tmp/opikey.txt ghcr.io/opiproject/spdk:main spdk_nvme_perf     -r 'traddr:127.0.0.1 trtype:TCP adrfam:IPv4 trsvcid:8888 subnqn:nqn.2022-09.io.spdk:opitest2 hostnqn:nqn.2014-08.org.nvmexpress:uuid:feb98abe-d51f-40c8-b348-2753f3571d3c' -c 0x1 -q 1 -o 4096 -w randread -t 10 -S ssl --psk-path /tmp/opikey.txt | tee log.txt
 grep "Total" log.txt
@@ -107,9 +102,10 @@ grep "Total" log.txt
 "${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 GetNvmePath "{name: 'nvmeRemoteControllers/nvmetls17/nvmePaths/nvmetls17path0'}"
 "${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmePath "{name: 'nvmeRemoteControllers/nvmetls17/nvmePaths/nvmetls17path0'}"
 "${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeRemoteController "{name: 'nvmeRemoteControllers/nvmetls17'}"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeNamespace "{name : 'subsystems/subsystem2/namespaces/namespace2'}"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeController "{name : 'subsystems/subsystem2/controllers/controller2'}"
-"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeSubsystem "{name : 'subsystems/subsystem2'}"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeNamespace "{name : 'nvmeSubsystems/subsystem2/nvmeNamespaces/namespace2'}"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeController "{name : 'nvmeSubsystems/subsystem2/nvmeControllers/controller2'}"
+"${grpc_cli[@]}" call --json_input --json_output opi-spdk-server:50051 DeleteNvmeSubsystem "{name : 'nvmeSubsystems/subsystem2'}"
+
 
 # this is last line
 docker-compose ps -a


### PR DESCRIPTION
the used parent collection names are not consistent with ones described in [API](https://github.com/opiproject/opi-api/blob/main/storage/frontend_nvme.proto)

CI requires https://github.com/opiproject/godpu/pull/438 to pass

Unblocks HTTP frontend https://github.com/opiproject/opi-spdk-bridge/pull/878