### PR TITLE
[frontend][nvme][ctrl] UpdateNvmeController: use AllowMissing

### DIFF
--- a/pkg/frontend/nvme_controller.go
+++ b/pkg/frontend/nvme_controller.go
@@ -114,7 +114,7 @@ func (s *Server) DeleteNvmeController(ctx context.Context, in *pb.DeleteNvmeCont
 }
 
 // UpdateNvmeController updates an Nvme controller
-func (s *Server) UpdateNvmeController(_ context.Context, in *pb.UpdateNvmeControllerRequest) (*pb.NvmeController, error) {
+func (s *Server) UpdateNvmeController(ctx context.Context, in *pb.UpdateNvmeControllerRequest) (*pb.NvmeController, error) {
 	// check input correctness
 	if err := s.validateUpdateNvmeControllerRequest(in); err != nil {
 		return nil, err
@@ -122,11 +122,18 @@ func (s *Server) UpdateNvmeController(_ context.Context, in *pb.UpdateNvmeContro
 	// fetch object from the database
 	ctrlr, ok := s.Nvme.Controllers[in.NvmeController.Name]
 	if !ok {
-		if in.AllowMissing {
-			log.Printf("TODO: in case of AllowMissing, create a new resource, don;t return error")
+		if !in.AllowMissing {
+			err := status.Errorf(codes.NotFound, "unable to find key %s", in.NvmeController.Name)
+			return nil, err
 		}
-		err := status.Errorf(codes.NotFound, "unable to find key %s", in.NvmeController.Name)
-		return nil, err
+		// If AllowMissing is true and controller doesn't exist, create it
+		subsysID := utils.GetSubsystemIDFromNvmeName(in.NvmeController.Name)
+		ctrlrID := path.Base(in.NvmeController.Name)
+		return s.CreateNvmeController(ctx, &pb.CreateNvmeControllerRequest{
+			Parent:             utils.ResourceIDToSubsystemName(subsysID),
+			NvmeControllerId:   ctrlrID,
+			NvmeController:     in.NvmeController,
+		})
 	}
 	resourceID := path.Base(ctrlr.Name)
 	// update_mask = 2

--- a/pkg/frontend/nvme_controller_test.go
+++ b/pkg/frontend/nvme_controller_test.go
@@ -496,6 +496,7 @@ func TestFrontEnd_UpdateNvmeController(t *testing.T) {
 	t.Cleanup(utils.CheckTestProtoObjectsNotChanged(spec)(t, t.Name()))
 	t.Cleanup(checkGlobalTestProtoObjectsNotChanged(t, t.Name()))
 
+	unknownControllerName := utils.ResourceIDToControllerName(testSubsystemID, "unknown-controller-id")
 	tests := map[string]struct {
 		mask    *fieldmaskpb.FieldMask
 		in      *pb.NvmeController
@@ -504,69 +505,94 @@ func TestFrontEnd_UpdateNvmeController(t *testing.T) {
 		errCode codes.Code
 		errMsg  string
 		missing bool
+		subsys  bool
 	}{
 		"invalid fieldmask": {
-			&fieldmaskpb.FieldMask{Paths: []string{"*", "author"}},
-			&pb.NvmeController{
+			mask: &fieldmaskpb.FieldMask{Paths: []string{"*", "author"}},
+			in: &pb.NvmeController{
 				Name: testControllerName,
 				Spec: spec,
 			},
-			nil,
-			[]string{},
-			codes.Unknown,
-			fmt.Sprintf("invalid field path: %s", "'*' must not be used with other paths"),
-			false,
+			out:     nil,
+			spdk:    []string{},
+			errCode: codes.Unknown,
+			errMsg:  fmt.Sprintf("invalid field path: %s", "'*' must not be used with other paths"),
+			missing: false,
 		},
 		"valid request without SPDK": {
-			nil,
-			&pb.NvmeController{
+			mask: nil,
+			in: &pb.NvmeController{
 				Name: testControllerName,
 				Spec: spec,
 			},
-			&pb.NvmeController{
+			out: &pb.NvmeController{
 				Name: testControllerName,
 				Spec: spec,
 				Status: &pb.NvmeControllerStatus{
 					Active: true,
 				},
 			},
-			[]string{},
-			codes.OK,
-			"",
-			false,
+			spdk:    []string{},
+			errCode: codes.OK,
+			errMsg:  "",
+			missing: false,
 		},
 		"valid request with unknown key": {
-			nil,
-			&pb.NvmeController{
-				Name: utils.ResourceIDToVolumeName("unknown-id"),
+			mask: nil,
+			in: &pb.NvmeController{
+				Name: unknownControllerName,
 				Spec: spec,
 			},
-			nil,
-			[]string{},
-			codes.NotFound,
-			fmt.Sprintf("unable to find key %v", utils.ResourceIDToVolumeName("unknown-id")),
-			false,
+			out:     nil,
+			spdk:    []string{},
+			errCode: codes.NotFound,
+			errMsg:  fmt.Sprintf("unable to find key %v", unknownControllerName),
+			missing: false,
 		},
 		"unknown key with missing allowed": {
-			nil,
-			&pb.NvmeController{
-				Name: utils.ResourceIDToVolumeName("unknown-id"),
+			mask: nil,
+			in: &pb.NvmeController{
+				Name: unknownControllerName,
 				Spec: spec,
 			},
-			nil,
-			[]string{},
-			codes.NotFound,
-			fmt.Sprintf("unable to find key %v", utils.ResourceIDToVolumeName("unknown-id")),
-			true,
+			out: &pb.NvmeController{
+				Name: unknownControllerName,
+				Spec: &pb.NvmeControllerSpec{
+					Endpoint:         spec.Endpoint,
+					NvmeControllerId: proto.Int32(-1),
+					Trtype:           pb.NvmeTransportType_NVME_TRANSPORT_TYPE_TCP,
+				},
+				Status: &pb.NvmeControllerStatus{
+					Active: true,
+				},
+			},
+			spdk:    []string{`{"id":%d,"error":{"code":0,"message":""},"result":true}`},
+			errCode: codes.OK,
+			errMsg:  "",
+			missing: true,
+			subsys:  true,
+		},
+		"unknown key with missing allowed and SPDK failure": {
+			mask: nil,
+			in: &pb.NvmeController{
+				Name: unknownControllerName,
+				Spec: spec,
+			},
+			out:     nil,
+			spdk:    []string{`{"id":%d,"error":{"code":0,"message":""},"result":false}`},
+			errCode: codes.InvalidArgument,
+			errMsg:  fmt.Sprintf("Could not create CTRL: %v", unknownControllerName),
+			missing: true,
+			subsys:  true,
 		},
 		"malformed name": {
-			nil,
-			&pb.NvmeController{Name: "-ABC-DEF", Spec: spec},
-			nil,
-			[]string{},
-			codes.Unknown,
-			fmt.Sprintf("segment '%s': not a valid DNS name", "-ABC-DEF"),
-			false,
+			mask:    nil,
+			in:      &pb.NvmeController{Name: "-ABC-DEF", Spec: spec},
+			out:     nil,
+			spdk:    []string{},
+			errCode: codes.Unknown,
+			errMsg:  fmt.Sprintf("segment '%s': not a valid DNS name", "-ABC-DEF"),
+			missing: false,
 		},
 	}
 
@@ -577,6 +603,9 @@ func TestFrontEnd_UpdateNvmeController(t *testing.T) {
 			defer testEnv.Close()
 
 			testEnv.opiSpdkServer.Nvme.Controllers[testControllerName] = utils.ProtoClone(&testController)
+			if tt.subsys {
+				testEnv.opiSpdkServer.Nvme.Subsystems[testSubsystemName] = utils.ProtoClone(&testSubsystem)
+			}
 
 			request := &pb.UpdateNvmeControllerRequest{NvmeController: tt.in, UpdateMask: tt.mask, AllowMissing: tt.missing}
 			response, err := testEnv.client.UpdateNvmeController(testEnv.ctx, request)


### PR DESCRIPTION
This patch use AllowMissing parameter in UpdateNvmeController to actually update one as mentioned in #886 